### PR TITLE
Switch to puppeteer

### DIFF
--- a/lib/blacklist.js
+++ b/lib/blacklist.js
@@ -1,0 +1,152 @@
+
+'use strict';
+
+const _dns    = require( 'dns' );
+const _url    = require( 'url' );
+const _ip     = require( 'ip' );
+const _fs     = require( 'fs' );
+const _log4js = require( 'log4js' );
+const logger  = _log4js.getLogger( 'blacklog' );
+
+const SUCCESS             = 0;
+const HOST_NO_DNS         = 1;
+const HOST_BLACKLISTED    = 2;
+const HOST_IP_BLACKLISTED = 3;
+const HOST_INVALIDSCHEMA  = 4;
+const HOST_INVALID        = 5;
+
+_log4js.configure( {
+	appenders: {
+		"app": {
+			'type'      : 'file',
+			'filename'  : 'logs/blacklist.log',
+			'maxLogSize': 10485760,
+			'numBackups': 10,
+			},
+		},
+		"categories": {
+			"default": { "appenders": [ "app" ], "level": "DEBUG" }
+		}
+	});
+
+_log4js.PatternLayout = '%d{HH:mm:ss,SSS} p m';
+
+var ips       = [];
+var subnets   = [];
+var hostnames = [];
+
+function loadConfig() {
+	// Reset the arrays to support config reloads
+	ips       = [];
+	subnets   = [];
+	hostnames = [];
+
+	_fs.readFile( 'config/blacklist.dat', ( err, data ) => {
+		if ( err ) {
+			logger.error( process.pid + ': failed to load the blacklist:', err );
+			process.exit( 0 );
+		}
+
+		let lines = data.toString().split( '\n' );
+
+		lines.forEach( function( line ) {
+			line = line.trim();
+			if ( '' == line || line.match( /^\s*#/ ) ) {
+				return;
+			}
+			if ( _ip.isV4Format( line ) || _ip.isV6Format( line ) ) {
+				ips.push( line );
+			} else if ( line.match( /\d{1,2}$/ ) ) {
+				subnets.push( line );
+			} else {
+				hostnames.push( line );
+			}
+		});
+	});
+}
+
+function allowHost( hostname, callback ) {
+	let parsedUrl = _url.parse( hostname, false );
+	if ( ! parsedUrl || ! parsedUrl.hostname || ! parsedUrl.protocol ) {
+		return callback( ( ! parsedUri.host ? HOST_INVALID : HOST_INVALIDSCHEMA ) );
+	}
+
+	let disallow = SUCCESS;
+	hostnames.some( function( hostname ) {
+		if ( hostname == parsedUrl.hostname ) {
+			if ( 'pixel.wp.com' != parsedUrl.hostname ) {
+				logger.debug( process.pid + ': hostname match ' + parsedUrl.hostname + ' == ' + hostname );
+			}
+			disallow = HOST_BLACKLISTED;
+			return true;
+		}
+	});
+	if ( disallow ) {
+		return callback( disallow );
+	}
+
+	if ( _ip.isV4Format( parsedUrl.hostname ) || _ip.isV6Format( parsedUrl.hostname ) ) {
+		if ( _ip.isPrivate( parsedUrl.hostname ) ) {
+			return callback( HOST_IP_BLACKLISTED );
+		}
+		ips.some( function( ip ) {
+			if ( _ip.isEqual( ip, parsedUrl.hostname ) ) {
+				logger.debug( process.pid + ': IP match ' + ip + ' == ' + parsedUrl.hostname );
+				disallow = HOST_IP_BLACKLISTED;
+				return true;
+			}
+		});
+		if ( disallow ) {
+			return callback( disallow );
+		}
+		subnets.some( function( subnet ){
+			if ( _ip.cidrSubnet( subnet ).contains( parsedUrl.hostname ) ) {
+				logger.debug( process.pid + ': IP subnet match ' + subnet + ' == ' + parsedUrl.hostname );
+				disallow = HOST_IP_BLACKLISTED;
+				return true;
+			}
+		});
+		return callback( disallow );
+	} else {
+		_dns.resolve( parsedUrl.hostname, ( err, records ) => {
+			if ( err ) {
+				return callback( HOST_NO_DNS );
+			}
+			records.some( function( rec ) {
+				if ( _ip.isPrivate( rec ) ) {
+					disallow = HOST_IP_BLACKLISTED;
+					return true;
+				}
+				ips.some( function( ip ) {
+					if ( _ip.isEqual( ip, rec ) ) {
+						logger.debug( process.pid + ': IP match ' + ip + ' == ' + rec );
+						disallow = HOST_IP_BLACKLISTED;
+						return true;
+					}
+				});
+				if ( disallow ) {
+					return true;
+				}
+				subnets.some( function( subnet ){
+					if ( _ip.cidrSubnet( subnet ).contains( rec ) ) {
+						logger.debug( process.pid + ': IP subnet match ' + subnet + ' == ' + rec );
+						disallow = HOST_IP_BLACKLISTED;
+						return true;
+					}
+				});
+				if ( disallow ) {
+					return true;
+				}
+			});
+			return callback( disallow );
+		});
+	}
+}
+
+const exported = {
+	loadConfig,
+	allowHost,
+}
+
+module.exports = exported;
+

--- a/lib/master.js
+++ b/lib/master.js
@@ -1,12 +1,13 @@
 
+'use strict';
+
 process.title = 'mShots.JS - Master';
 
-var cluster = require( 'cluster' );
-var http = require( 'http' );
-var numWorkers = require( 'os' ).cpus().length * 2;
-var o_log4js = require( 'log4js' );
-var logger = o_log4js.getLogger( 'flog' );
-var fs = require( 'fs' );
+const cluster = require( 'cluster' );
+const http    = require( 'http' );
+const fs      = require( 'fs' );
+const _log4js = require( 'log4js' );
+const logger  = _log4js.getLogger( 'flog' );
 
 const MAX_WORKERS = 50;
 const MAX_NO_RESPONSE_COUNT = 3;
@@ -26,7 +27,8 @@ const HOST_INVALID = 4;
 const GENERAL_ERROR = 5;
 const FORMAT_ERROR = 6;
 
-var arrWorkers = new Array();
+var arrWorkers = [];
+var numWorkers = require( 'os' ).cpus().length * 2
 var messageStatus = 'requesting';
 var queuetotal = 0;
 var processed = 0;
@@ -35,35 +37,41 @@ var error_dns = 0;
 var error_hostname = 0;
 var error_blacklist = 0;
 
-o_log4js.configure( {
-	appenders: [ {
-		'type'      : 'file',
-		'filename'  : 'logs/mshots.log',
-		'maxLogSize': 10485760,
-		'backups'   : 10,
-		'category'  : 'flog',
-		'levels'    : 'DEBUG',
+_log4js.configure( {
+	appenders: {
+		"app": {
+			'type'      : 'file',
+			'filename'  : 'logs/mshots.log',
+			'maxLogSize': 10485760,
+			'numBackups': 10,
+			'category'  : 'flog',
+			},
+		},
+		"categories": {
+			"default": { "appenders": [ "app" ], "level": "DEBUG" }
 		}
-	]
-});
+	});
+
+_log4js.PatternLayout = '%d{HH:mm:ss,SSS} p m';
 
 var args = process.argv.slice(2);
-for (var i = 0; i < args.length; i++)
-{
+for ( var i = 0; i < args.length; i++ ) {
 	if ( args[i] == '-n' ) {
 		i++;
 		if ( i < args.length ) {
-			if( ! isNaN( args[i] ) )
+			if ( ! isNaN( args[i] ) ) {
 				numWorkers = args[i];
-			if( numWorkers > MAX_WORKERS )
+			}
+			if ( numWorkers > MAX_WORKERS ) {
 				numWorkers = MAX_WORKERS;
+			}
 		}
 	}
 }
 
 cluster.setupMaster( {
 	exec   : './lib/worker.js',
-	silent : true,
+	silent : false,
 });
 
 cluster.on( 'online', function( worker ) {
@@ -75,7 +83,7 @@ cluster.on( 'disconnect', function( worker ) {
 });
 
 cluster.on( 'exit', function( worker, code, signal ) {
-	if ( true == worker.suicide ) {
+	if ( true == worker.exitedAfterDisconnect ) {
 		logger.debug( 'worker thread #' + worker.id + ' (pid:' + worker.process.pid + ') is shutting down.' );
 	} else {
 		var exitCode = worker.process.exitCode;
@@ -92,7 +100,7 @@ cluster.on( 'exit', function( worker, code, signal ) {
 
 function updateStats() {
 	if ( messageStatus == 'requesting' ) {
-		var totalO = new Object();
+		let totalO = {};
 		totalO.queuetotal = queuetotal;
 		totalO.processed = processed;
 		totalO.errortotal = error_misc + error_dns + error_hostname + error_blacklist;
@@ -109,7 +117,7 @@ function updateStats() {
 		setTimeout( updateStats, ( STATS_UPDATE_INTERVAL_MSECS / 2 ) );
 	} else {
 		for ( var count in arrWorkers ) {
-			var killSignalled = false;
+			let killSignalled = false;
 			if ( 'pong' == arrWorkers[count].replytype ) {
 				arrWorkers[count].no_response_count = 0;
 			} else {
@@ -117,11 +125,11 @@ function updateStats() {
 				if ( arrWorkers[count].no_response_count >= MAX_NO_RESPONSE_COUNT ) {
 					try {
 						logger.debug( 'Worker unresponsive: ' + arrWorkers[count].worker.process.pid + ', setting it "free".' );
-						var spawn = require('child_process').spawn,
-				    	killer = spawn('kill', [ '-s', '9', arrWorkers[count].worker.process.pid ] );
-				    	killSignalled = true;
-				    }
-				    catch ( Exception ) {
+						const spawn = require( 'child_process' ).spawn,
+						killer = spawn('kill', [ '-s', '9', arrWorkers[count].worker.process.pid ] );
+						killSignalled = true;
+					}
+					catch ( Exception ) {
 						logger.error( 'error "killing" worker in slot ' + count );
 					}
 				}
@@ -134,9 +142,9 @@ function updateStats() {
 					if ( ( now - arrWorkers[count].lastQueueDelete ) >= MAX_QUEUE_PROCESS_WAIT_MSECS ) {
 						try {
 							logger.debug( 'Worker not deleting queue: ' + arrWorkers[count].worker.process.pid + ', setting it "free".' );
-							var spawn = require('child_process').spawn,
-					    	killer = spawn('kill', [ '-s', '9', arrWorkers[count].worker.process.pid ] );
-					    }
+							const spawn = require( 'child_process' ).spawn,
+							killer = spawn('kill', [ '-s', '9', arrWorkers[count].worker.process.pid ] );
+						}
 						catch ( Exception ) {
 							logger.error( 'error "killing" worker in slot ' + count );
 						}
@@ -170,16 +178,17 @@ function updateStats() {
 				for ( var count in arrWorkers ) {
 					var w_pid = 0;
 					try {
-						if ( undefined != arrWorkers[count].worker )
+						if ( undefined != arrWorkers[count].worker ) {
 							w_pid = arrWorkers[count].worker.process.pid;
+						}
 					}
-				    catch ( Exception ) {
+					catch ( Exception ) {
 						;
 					}
 					threadFile.write( w_pid + '\t' +
-									arrWorkers[count].site_queue.length + '\t' +
-									arrWorkers[count].no_response_count + '\t' +
-									( ( null == arrWorkers[count].lastQueueDelete ) ? "-" : ( now - arrWorkers[count].lastQueueDelete ) + "ms" ) + '\n' );
+						arrWorkers[count].site_queue.length + '\t' +
+						arrWorkers[count].no_response_count + '\t' +
+						( ( null == arrWorkers[count].lastQueueDelete ) ? "-" : ( now - arrWorkers[count].lastQueueDelete ) + "ms" ) + '\n' );
 				}
 				threadFile.end();
 			});
@@ -210,7 +219,7 @@ function workerCallback( msg ) {
 			case 'queue-add': {
 				var siteQueued = false;
 				for ( var count in arrWorkers ) {
-					for (var queuecount in arrWorkers[count].site_queue ) {
+					for ( var queuecount in arrWorkers[count].site_queue ) {
 						if ( ( arrWorkers[count].site_queue[queuecount].url == msg.payload.url ) &&
 							( arrWorkers[count].site_queue[queuecount].file == msg.payload.file ) ) {
 							siteQueued = true;

--- a/lib/mshots.js
+++ b/lib/mshots.js
@@ -1,17 +1,24 @@
 
-var master_process = require( './master' );
-var o_log4js = require( 'log4js' );
+'use strict';
+
+const master_process = require( './master' );
+const o_log4js = require( 'log4js' );
+
 o_log4js.configure( {
-  appenders: [ {
-		'type'      : 'file',
-		'filename'  : 'logs/mshots.log',
-		'maxLogSize': 10485760,
-		'backups'   : 10,
-		'category'  : 'flog',
-		'levels'    : 'DEBUG',
+	appenders: {
+		"app": {
+			'type'      : 'file',
+			'filename'  : 'logs/mshots.log',
+			'maxLogSize': 10485760,
+			'numBackups': 10,
+			'category'  : 'flog',
+			},
+		},
+		"categories": {
+			"default": { "appenders": [ "app" ], "level": "DEBUG" }
 		}
-	]
-});
+	});
+
 o_log4js.PatternLayout = '%d{HH:mm:ss,SSS} p m';
 
 function stop_workerthreads() {

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -48,142 +48,310 @@ var reload_config      = false;
 var time_downloading   = 0;
 var browser            = null;
 var default_UA         = '';
-		}
-	]
-});
 
-function save_snapshot() {
-	snapper.save_thumbnail( p_uri, p_filename, p_width, p_height, function( err_desc, returnCode ) {
-			try {
-				if ( SUCCESS != returnCode ) {
-					logger.error( process.pid + ': ' + err_desc );
-				}
-			}
-			catch ( Exception ) {
-				logger.error( process.pid + ': exception in save_page callback function:' + Exception.toString() );
-			}
-			finally {
-				time_downloading = 0;
-				if ( site_queue.length == 0 )
-					snapper.setBlankPage();
-				var resultO = new Object();
-				resultO.url = p_uri;
-				resultO.file = p_filename;
-				resultO.status = returnCode;
-				process.send( { replytype: 'queue-del', workerid: process.pid, payload: resultO } );
-				downloading = false;
-			}
-		});
+function init_browser() {
+	(async() => {
+		browser = await _puppeteer.launch( { headless: true, timeout: 30000, ignoreHTTPSErrors: true } ).
+			catch( e => {
+				logger.error( process.pid + ': Failed to launch the browser: ' + e.toString() );
+				process.exit( EXIT_UNRESPONSIVE );
+			});
+
+		default_UA = await browser.userAgent();
+	})();
 }
 
-function take_snapshot() {
-	setTimeout( process_download_events, 50 );
-	snapper.load_page( p_uri, p_filename, p_width, p_height, function( err_desc, returnCode ) {
-		try {
-			p_prev_timeout_uri = "";
-			if ( SUCCESS == returnCode ) {
-				gen_error_count = 0;
-				setTimeout( save_snapshot, 400 );
-			} else {
-				time_downloading = 0;
-				snapper.abortDownload();
-				logger.error( process.pid + ': ' + err_desc );
+function take_snapshot( p_uri, p_filename, p_width, p_height ) {
+	let m_uri = p_uri;
+	if ( ! m_uri.match( /^([a-z][a-z0-9+\-.]*):/i ) ) {
+		m_uri = 'http://' + m_uri;
+	}
 
-				if ( GENERAL_ERROR == returnCode ) {
-					gen_error_count++;
-					if ( gen_error_count >= GENERAL_ERROR_LIMIT )
-						process.exit( EXIT_ERROR_LIMIT );
-				} else
-					gen_error_count = 0;
+	const parsedUri = _url.parse( m_uri );
+	if ( ! parsedUri || ! parsedUri.host || ! parsedUri.protocol ) {
+		saveAs( 404, p_filename );
+		time_downloading = 0;
+		downloading = false;
+		logger.error( process.pid + ': Invalid URL: ' + p_uri + '. Saved as 404 and continued with queue.' );
+		process.send({
+			replytype: 'queue-del',
+			workerid: process.pid,
+			payload: {
+				status: ( ! parsedUri.host ? HOST_INVALID : HOST_INVALIDSCHEMA ),
+				url   : p_uri,
+				file  : p_filename,
+			}
+		});
+		return;
+	}
 
-				var resultO = new Object();
-				resultO.url = p_uri;
-				resultO.file = p_filename;
-				resultO.status = returnCode;
-				process.send( { replytype: 'queue-del', workerid: process.pid, payload: resultO } );
-				downloading = false;
+	let redirect_uri   = m_uri;
+	let redirect_count = 0;
+	let block_all_code = 0;
+	let error_code     = -1;
+	let page_loaded    = false;
+
+	(async() => {
+		if ( null === browser ) {
+			await init_browser();
+		}
+		const page = await browser.newPage();
+
+		await page.setUserAgent( default_UA + ' WordPress.com mShots' );
+		await page.setCacheEnabled( false );
+		await page.setRequestInterception( true );
+		await page._client.send( 'Page.setDownloadBehavior', { behavior: 'deny' } );
+
+		page.setViewport( { width: p_width, height: p_height } );
+
+		await page.on( 'request', request => {
+			if ( 0 < block_all_code ) {
+				request.abort( 'accessdenied' );
+				return;
+			}
+			_blacklist.allowHost( request.url(), function( result ) {
+				if ( SUCCESS === result ) {
+					request.continue();
+				} else {
+					let reason = 'ACCESS DENIED';
+					let abortReason = 'failed';
+					switch ( result )  {
+					case HOST_NO_DNS:
+						reason = 'HOST_NO_DNS';
+						abortReason = 'namenotresolved';
+						break;
+					case HOST_BLACKLISTED:
+						reason = 'HOST_BLACKLISTED';
+						abortReason = 'accessdenied';
+						break;
+					case HOST_IP_BLACKLISTED:
+						reason = 'HOST_IP_BLACKLISTED';
+						abortReason = 'accessdenied';
+						break;
+					case HOST_INVALIDSCHEMA:
+						reason = 'HOST_INVALIDSCHEMA';
+						break;
+					case HOST_INVALID:
+						reason = 'HOST_INVALID';
+						break;
+					}
+					if ( ! request.url().match( /https?:\/\/pixel.wp.com\// ) ) {
+						logger.debug( process.pid + ': ' + reason + ':', request.method(), request.url() );
+					}
+					request.abort( abortReason );
+				}
+			});
+		});
+
+		await page.on( 'response', response => {
+			const status = response.status();
+			const url    = response.request().url();
+
+			if ( url == redirect_uri && ( 301 == status || 302 == status || 307 == status || 308 == status ) ) {
+				redirect_count++;
+				redirect_uri = response.headers().location;
+				if ( redirect_count > REDIRECT_LIMIT ) {
+					logger.error( process.pid + ': redirect limit for ' + p_uri + ' reached at ', redirect_uri );
+					block_all_code = GENERAL_ERROR;
+				}
+			}
+		});
+
+		await page.on( 'load', () => {
+			logger.debug( process.pid + ': loaded: ' + page.url() );
+			page_loaded = true;
+		});
+
+		await page.on( 'requestfailed', request => {
+			if ( 'document' == request.resourceType() && request.response() ) {
+				const content_type = request.response().headers()['content-type'];
+				logger.debug( process.pid + ': failed request for content type = ' + content_type );
+				block_all_code = GENERAL_ERROR;
+				error_code = 415; // Unsupported Media Type
+				saveAsUnsupportedContent( p_filename, content_type );
+			}
+		});
+
+		const response = await page.goto( m_uri, { waitUntil: 'networkidle2' } ).
+			catch( e => {
+				logger.error( process.pid + ': Failed to load ' + m_uri + ': ' + e.toString() );
+				if ( -1 !== e.toString().indexOf( 'ERR_ACCESS_DENIED' ) ) {
+					error_code = 403;
+				} else if ( -1 !== e.toString().indexOf( 'Error: Navigation Timeout Exceeded' ) ) {
+					error_code = 0;
+				}
+			});
+
+		if ( response && response.ok() || page_loaded ) {
+			await page.waitFor( 2000 );
+			makeDirIfRequired( _path.dirname( p_filename ) );
+			await page.screenshot( { path: p_filename, fullPage: false, type: 'jpeg', quality: 90 } );
+			await page.close();
+			logger.debug( process.pid + ': snapped: ' + p_uri );
+
+			let pages = await browser.pages();
+			pages.forEach( function( p ) {
+				p.close();
+			});
+
+			process.send({
+				replytype: 'queue-del',
+				workerid: process.pid,
+				payload: {
+					status: SUCCESS,
+					url   : p_uri,
+					file  : p_filename,
+				}
+			});
+
+			time_downloading = 0;
+			downloading = false;
+			return;
+		}
+
+		await page.close();
+		let pages = await browser.pages();
+		pages.forEach( function( p ) {
+			p.close();
+		});
+
+		let status = ( response ? response.status() : error_code );
+
+		switch ( status ) {
+			case 0:
+				saveAs( 404, p_filename );
+				logger.error( process.pid + ': Timed out loading ' + p_uri + '. Saved as 404.' );
+				break;
+			case 401:
+				saveAs( 401, p_filename );
+				logger.error( process.pid + ': Failed to load ' + p_uri + '. Authentication required.' );
+				break;
+			case 403:
+				saveAs( 403, p_filename );
+				logger.error( process.pid + ': Failed to load ' + p_uri + '. Access denied.' );
+				break;
+			case 415:
+				logger.error( process.pid + ': Failed to load ' + p_uri + '. Unsupported content.' );
+				break;
+			case 400:
+			case 404:
+			case 500:
+			default:
+				saveAs( 404, p_filename );
+				logger.error( process.pid + ': Failed to load ' + p_uri + '. Saved as 404.' );
+				break;
+		}
+
+		process.send({
+			replytype: 'queue-del',
+			workerid: process.pid,
+			payload: {
+				status: ( 0 < block_all_code ? block_all_code : GENERAL_ERROR ),
+				url   : p_uri,
+				file  : p_filename,
+			}
+		});
+
+		time_downloading = 0;
+		downloading = false;
+	})();
+}
+
+function makeDirIfRequired( dirname ) {
+	if ( ! _fs.existsSync( dirname ) ) {
+		let p = dirname.split('/');
+		for ( var i = 1; i < p.length; i++) {
+			let part_path = p.slice( 0, i + 1 ).join('/');
+			if ( ! _fs.existsSync( part_path ) ) {
+				_fs.mkdirSync( part_path )
 			}
 		}
-		catch ( Exception ) {
-			time_downloading = 0;
-			logger.error( process.pid + ': exception in save_page callback function:' + Exception.toString() );
-			var resultO = new Object();
-			resultO.url = p_uri;
-			resultO.file = p_filename;
-			resultO.status = returnCode;
-			process.send( { replytype: 'queue-del', workerid: process.pid, payload: resultO } );
-			downloading = false;
+	}
+}
+
+function saveAs( httpCode, filename ) {
+	try {
+		if ( 0 == filename.length ) {
+			return;
 		}
-	});
+
+		if ( _fs.existsSync( filename ) ) {
+			_fs.unlinkSync( filename );
+		} else {
+			makeDirIfRequired( _path.dirname( filename ) );
+		}
+
+		_fs.copyFileSync( './public_html/icons/' + httpCode + '.jpg' , filename );
+
+		let now_sec = new Date().getTime() / 1000;
+		// Set the last access time to be 1 hour less than a
+		// full day, so it can get re-requested in an hour.
+		let actime = now_sec - 82800;
+
+		_fs.utimes( filename, actime, actime, () => { ; } );
+	}
+	catch ( Exception ) {
+		logger.error( process.pid + ': exception in function saveAs( ' +
+			httpCode + ', ' + filename + ' ): ' + Exception.toString() );
+	}
+}
+
+function saveAsUnsupportedContent( filename, content_type ) {
+	try {
+		if ( 0 == filename.length ) {
+			return;
+		}
+
+		makeDirIfRequired( _path.dirname( filename ) );
+
+		if ( -1 !== content_type.indexOf( "video/" ) ) {
+			if ( _fs.existsSync( filename ) ) {
+				_fs.unlinkSync( filename );
+			}
+			_fs.copyFileSync( './public_html/icons/video.jpg' , filename );
+		} else if ( content_type.includes( "audio/" ) ) {
+			if ( _fs.existsSync( filename ) ) {
+				_fs.unlinkSync( filename );
+			}
+			_fs.copyFileSync( './public_html/icons/audio.jpg' , filename );
+		} else if ( content_type.includes( "application/x-rar-compressed" ) ||
+					content_type.includes( "application/x-tar" ) ||
+					content_type.includes( "application/x-gtar" ) ||
+					content_type.includes( "application/zip" ) ) {
+			if ( _fs.existsSync( filename ) ) {
+				_fs.unlinkSync( filename );
+			}
+			_fs.copyFileSync( './public_html/icons/archive.jpg' , filename );
+		} else {
+			if ( _fs.existsSync( filename ) ) {
+				_fs.unlinkSync( filename );
+			}
+			_fs.copyFileSync( './public_html/icons/document.jpg' , filename );
+		};
+	}
+	catch ( Exception ) {
+		logger.error( process.pid + ': exception in function unsupportedContent( ' +
+			filename + ', ' + content_type + ' ): ' + Exception.toString() );
+	}
+
 }
 
 function check_site_queue() {
 	if ( false === downloading ) {
 		if ( reload_config ) {
 			reload_config = false;
-			snapper.reloadBlacklistConfig();
+			_blacklist.loadConfig();
 			logger.debug( process.pid + ': blacklist file reloaded' );
-			snapper.reloadConfig();
-			logger.debug( process.pid + ': config file reloaded' );
 		}
 		if ( site_queue.length > 0 ) {
 			downloading = true;
 			logger.debug( process.pid + ': site queue size = ' + site_queue.length );
+
 			var s_details = site_queue[0];
 			site_queue.shift();
 			logger.debug( process.pid + ': snapping: ' + s_details.url );
-			p_uri = s_details.url;
-			p_filename = s_details.file;
-			take_snapshot( p_uri, p_filename, p_width, p_height );
+			take_snapshot( s_details.url, s_details.file, s_details.width, s_details.height );
 		}
-	}
-}
-
-function process_events() {
-	if ( true === running ) {
-		try {
-			snapper.processEvents();
-			if ( true === downloading ) {
-				time_downloading++;
-				if ( time_downloading >= LOAD_TIMEOUT ) {
-					time_downloading = 0;
-					if ( snapper.pageLoadProgress() >= MIN_LOAD_PRECENTAGE ) {
-						if ( p_prev_timeout_uri == p_uri ) {
-							p_prev_timeout_uri = "";
-							logger.trace( process.pid + ': ' + p_uri + ' previously timed out at progress ' +
-											snapper.pageLoadProgress() + '%, unresponsive, to the ether.' );
-							process.exit( EXIT_UNRESPONSIVE );
-						} else {
-							p_prev_timeout_uri = p_uri;
-							logger.trace( process.pid + ': ' + p_uri + ' timed out at progress ' +
-											snapper.pageLoadProgress() + '%, forcing a snapshot.' );
-							snapper.setForceSnapshot();
-							snapper.stopLoadingPage();
-						}
-					} else {
-						p_prev_timeout_uri = "";
-						snapper.abortDownload();
-						logger.error( process.pid + ': ' + p_uri + ' load timed out. Saved as 404 and continued with queue.' );
-						downloading = false;
-					}
-				}
-			} else {
-				time_downloading = 0;
-				check_site_queue();
-			}
-		}
-		finally {
-			setTimeout( process_events, 1000 );
-		}
-	} else {
-		snapper.exit();
-	}
-}
-
-function process_download_events() {
-	if ( ( true === downloading ) && ( true === running ) ) {
-		snapper.processEvents();
-		setTimeout( process_download_events, 25 );
 	}
 }
 
@@ -200,8 +368,33 @@ function add_to_queue( siteObject ) {
 	site_queue.push( siteObject );
 }
 
-setTimeout( process_events, 2000 );
+function process_events() {
+	if ( ! running ) {
+		process.exit( 0 );
+	}
 
-exports.add_to_queue  = add_to_queue;
-exports.shutdown      = shutdown;
-exports.reload_config = reload_all_config;
+	if ( downloading ) {
+		time_downloading++;
+		if ( time_downloading >= LOAD_TIMEOUT ) {
+			logger.error( process.pid + ': load timed out. Forcing exit.' );
+			process.exit( EXIT_UNRESPONSIVE );
+		}
+	} else {
+		time_downloading = 0;
+		check_site_queue();
+	}
+}
+setInterval( process_events, 1000 );
+
+_blacklist.loadConfig();
+
+const exported = {
+	add_to_queue,
+	shutdown,
+	reload_all_config,
+	init_browser,
+}
+
+module.exports = exported;
+
+

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -1,44 +1,53 @@
 
-global.snapper = require( './snapper.node' );
-var o_log4js = require( 'log4js' );
-var logger = o_log4js.getLogger( 'flog' );
+'use strict';
 
-global.site_queue = new Array();
-global.running = true;
-global.downloading = false;
-global.reload_config = false;
-global.time_downloading = 0;
+const _puppeteer = require( 'puppeteer' );
+const _url       = require( 'url' );
+const _fs        = require( 'fs' );
+const _path      = require( 'path' );
+const _blacklist = require( './blacklist' )
 
-global.p_uri = "";
-global.p_filename = "";
-global.p_width = 1280;
-global.p_height = 960;
-global.p_prev_timeout_uri = "";
+const o_log4js  = require( 'log4js' );
+const logger    = o_log4js.getLogger( 'flog' );
 
-var gen_error_count = 0;
+const LOAD_TIMEOUT        = 40;
+const REDIRECT_LIMIT      =  2;
 
-const LOAD_TIMEOUT = 30;
-const MIN_LOAD_PRECENTAGE = 85;
-const GENERAL_ERROR_LIMIT = 3;
+const SUCCESS             = 0;
+const HOST_NO_DNS         = 1;
+const HOST_BLACKLISTED    = 2;
+const HOST_IP_BLACKLISTED = 3;
+const HOST_INVALIDSCHEMA  = 4;
+const HOST_INVALID        = 5;
+const GENERAL_ERROR       = 6;
 
-const SUCCESS = 0;
-const HOST_NO_DNS = 1;
-const HOST_BLACKLISTED = 2;
-const HOST_INVALIDSCHEMA = 3;
-const HOST_INVALID = 4;
-const GENERAL_ERROR = 5;
-
-const EXIT_UNRESPONSIVE = 4;
-const EXIT_ERROR_LIMIT  = 5;
+const EXIT_UNRESPONSIVE   = 4;
+const EXIT_ERROR_LIMIT    = 5;
 
 o_log4js.configure( {
-  appenders: [ {
-		'type'      : 'file',
-		'filename'  : 'logs/mshots.log',
-		'maxLogSize': 10485760,
-		'backups'   : 10,
-		'category'  : 'flog',
-		'levels'    : 'DEBUG',
+	appenders: {
+		"app": {
+			'type'      : 'file',
+			'filename'  : 'logs/mshots.log',
+			'maxLogSize': 10485760,
+			'numBackups': 10,
+			'category'  : 'flog',
+			},
+		},
+		"categories": {
+			"default": { "appenders": [ "app" ], "level": "DEBUG" }
+		}
+	});
+
+o_log4js.PatternLayout = '%d{HH:mm:ss,SSS} p m';
+
+var site_queue         = [];
+var running            = true;
+var downloading        = false;
+var reload_config      = false;
+var time_downloading   = 0;
+var browser            = null;
+var default_UA         = '';
 		}
 	]
 });

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,11 +1,14 @@
 
+'use strict';
+
 process.title = "mShots.JS - Worker";
 
-var http = require( 'http' );
-var url = require( 'url' );
-var snapshot = require( './snapshot' );
-var o_log4js = require( 'log4js' );
-var logger = o_log4js.getLogger( 'flog' );
+const _http     = require( 'http' );
+const _url      = require( 'url' );
+const _cypher   = require( 'crypto' );
+const _snapshot = require( './snapshot' );
+const _log4js   = require( 'log4js' );
+const logger    = _log4js.getLogger( 'flog' );
 
 const MAX_PROCESS_MEM_USAGE = 500 * 1024 * 1024;
 const EXIT_MAXRAMUSAGE = 1;
@@ -25,17 +28,22 @@ var global_queuetotal = 0;
 var global_processed = 0;
 var global_errortotal = 0;
 
-o_log4js.configure( {
-	appenders: [ {
-		'type'      : 'file',
-		'filename'  : 'logs/mshots.log',
-		'maxLogSize': 10485760,
-		'backups'   : 10,
-		'category'  : 'flog',
-		'levels'    : 'DEBUG',
+_log4js.configure( {
+	appenders: {
+		"app": {
+			'type'      : 'file',
+			'filename'  : 'logs/mshots.log',
+			'maxLogSize': 10485760,
+			'numBackups': 10,
+			'category'  : 'flog',
+			},
+		},
+		"categories": {
+			"default": { "appenders": [ "app" ], "level": "DEBUG" }
 		}
-	]
-});
+	});
+
+_log4js.PatternLayout = '%d{HH:mm:ss,SSS} p m';
 
 var args = process.argv.slice( 2 );
 for (var i = 0; i < args.length; i++) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -55,6 +55,27 @@ for (var i = 0; i < args.length; i++) {
 	}
 }
 
+function validateFileName( request ) {
+	let url_parts = request.url.split( "://" );
+	let host = '';
+	if ( url_parts.length > 1 ) {
+		host = url_parts[1].split( "/" )[0];
+	} else {
+		host = url_parts[0].split( "/" )[0];
+	}
+
+	let viewport = '';
+	if ( request.width != VIEWPORT_DEFAULT_W || request.height != VIEWPORT_DEFAULT_H ) {
+		viewport = '_' + request.width + 'x' + request.height;
+	}
+
+	let s_filename = _cypher.createHash( 'md5' ).update( request.url ).digest( 'hex' ) + viewport + '.jpg';
+	let s_host = _cypher.createHash( 'sha1' ).update( host ).digest( 'hex' );
+	let s_fullpath = '/opt/mshots/public_html/thumbnails/' + s_host.substring( 0, 3 ) + "/" + s_host + "/" + s_filename;
+
+	return ( s_fullpath == request.file );
+}
+
 var HTTPListner = function() {
 
 	var routes = {
@@ -66,38 +87,46 @@ var HTTPListner = function() {
 
 		'/queue' : function( request, response ) {
 			response.writeHead( 200, { 'Content-Type': 'text/plain' } );
-			var _get = url.parse( request.url, true ).query;
+			var _get = _url.parse( request.url, true ).query;
 			if ( ( undefined != _get['url'] ) && ( undefined != _get['f'] ) && ( "" != _get['url'] ) && ( "" != _get['f'] ) ) {
-				if ( readyToSendRequests ) {
-					response.write( 'Snap\n' );
-					response.end();
-					var site = new Object();
-					site.url = _get['url'];
-					site.file =_get['f'];
-
-					if ( undefined == _get['vpw'] || isNaN( _get['vpw'] ) ) {
-						site.width = VIEWPORT_DEFAULT_W;
-					} else {
-						site.width = parseInt( _get['vpw'] );
-						if ( site.width > VIEWPORT_MAX_W )
-							site.width = VIEWPORT_MAX_W;
-						else if ( site.width < VIEWPORT_MIN_W )
-							site.width = VIEWPORT_MIN_W;
-					}
-					if ( undefined == _get['vph'] || isNaN( _get['vph'] ) ) {
-						site.height = VIEWPORT_DEFAULT_H;
-					} else {
-						site.height = parseInt( _get['vph'] );
-						if ( site.height > VIEWPORT_MAX_H )
-							site.height = VIEWPORT_MAX_H;
-						else if ( site.height < VIEWPORT_MIN_H )
-							site.height = VIEWPORT_MIN_H;
-					}
-
-					process.send( { replytype: 'queue-add', workerid: process.pid, payload: site } );
-				} else {
+				if ( ! readyToSendRequests ) {
 					response.write( 'Slap\n' );
 					response.end();
+					return;
+				}
+
+				response.write( 'Snap\n' );
+				response.end();
+
+				let site = {};
+				site.url = _get['url'];
+				site.file =_get['f'];
+
+				if ( undefined == _get['vpw'] || isNaN( _get['vpw'] ) ) {
+					site.width = VIEWPORT_DEFAULT_W;
+				} else {
+					site.width = parseInt( _get['vpw'] );
+					if ( site.width > VIEWPORT_MAX_W ) {
+						site.width = VIEWPORT_MAX_W;
+					} else if ( site.width < VIEWPORT_MIN_W ) {
+						site.width = VIEWPORT_MIN_W;
+					}
+				}
+				if ( undefined == _get['vph'] || isNaN( _get['vph'] ) ) {
+					site.height = VIEWPORT_DEFAULT_H;
+				} else {
+					site.height = parseInt( _get['vph'] );
+					if ( site.height > VIEWPORT_MAX_H ) {
+						site.height = VIEWPORT_MAX_H;
+					} else if ( site.height < VIEWPORT_MIN_H ) {
+						site.height = VIEWPORT_MIN_H;
+					}
+				}
+
+				if ( ! validateFileName( site ) ) {
+					logger.error( process.pid + ': invalid filename: validation failed' );
+				} else {
+					process.send( { replytype: 'queue-add', workerid: process.pid, payload: site } );
 				}
 			} else {
 				response.write( 'Malformed request\n' );
@@ -143,18 +172,18 @@ var HTTPListner = function() {
 
 	var close_handler = function() {
 		logger.trace( process.pid + ': HTTP server has been shutdown. Shutting down snapshot object.' );
-		snapshot.shutdown();
+		_snapshot.shutdown();
 	};
 
 	var error_handler = function( err ) {
 		logger.error( process.pid + ': HTTP error encountered: ' + err );
 	}
 
-	var _server = http.createServer().
-					 addListener( 'request', request_handler )
-					.addListener( 'close', close_handler )
-					.addListener( 'error', error_handler )
-				.listen( PortNum );
+	var _server = _http.createServer().
+		 addListener( 'request', request_handler )
+		.addListener( 'close', close_handler )
+		.addListener( 'error', error_handler )
+		.listen( PortNum );
 };
 
 process.on( 'SIGUSR2', function() {
@@ -163,8 +192,8 @@ process.on( 'SIGUSR2', function() {
 });
 
 process.on( 'uncaughtException', function( err_desc ) {
-	// this most often called when the process.send node.JS bug creeps in
-	// so we exit the process and allow the Mater to redistribute the queue
+	// print and exit the process and allow the Master to redistribute the queue
+	console.log( process.pid + ': uncaughtException error: ' + err_desc );
 	logger.error( process.pid + ': uncaughtException error: ' + err_desc );
 	process.exit( EXIT_ERROR );
 });
@@ -183,19 +212,21 @@ process.on( 'message', function( msg ) {
 				break;
 			}
 			case 'queue-add': {
-				if ( process.memoryUsage().rss > MAX_PROCESS_MEM_USAGE )
+				if ( process.memoryUsage().rss > MAX_PROCESS_MEM_USAGE ) {
 					process.exit( EXIT_MAXRAMUSAGE );
-				else
-					snapshot.add_to_queue( msg.payload );
+				} else {
+					_snapshot.add_to_queue( msg.payload );
+				}
 				break;
 			}
 			case 'reload': {
-				snapshot.reload_config();
+				_snapshot.reload_all_config();
 				break;
 			}
 			default: {
-				if ( readyToSendRequests )
+				if ( readyToSendRequests ) {
 					process.send( { replytype: 'unknown', workerid: msg.id, payload: 0 } );
+				}
 			}
 		}
 	}
@@ -204,8 +235,12 @@ process.on( 'message', function( msg ) {
 	}
 });
 
+// Initialize the snapshot browser
+_snapshot.init_browser();
+
 // node.JS currently has an issue with the HTTP listener initialising and the inter-process
 // coms, so we give the HTTP listening time to init before calling any process.send commands
-setTimeout( function () { readyToSendRequests = true; }, 2000 );
+setTimeout( function () { readyToSendRequests = true; }, 500 );
 
 new HTTPListner();
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1957 @@
+{
+  "name": "mShots.NodeJS",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "addressparser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
+      "integrity": "sha1-R6++GiqSYhkdtoOOT9HTm0CCF0Y=",
+      "optional": true
+    },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "5.0.0"
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "optional": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "amqplib": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.5.2.tgz",
+      "integrity": "sha512-l9mCs6LbydtHqRniRwYkKdqxVa6XMz3Vw1fh+2gJaaVgTM6Jk3o8RccAKWKtlhT1US5sWrFh+KKxsVUALURSIA==",
+      "optional": true,
+      "requires": {
+        "bitsyntax": "0.0.4",
+        "bluebird": "3.5.1",
+        "buffer-more-ints": "0.0.2",
+        "readable-stream": "1.1.14",
+        "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "optional": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "optional": true
+        }
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "optional": true
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "optional": true
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "ast-types": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
+      "integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA==",
+      "optional": true
+    },
+    "async": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+      "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+      "optional": true,
+      "requires": {
+        "lodash": "4.17.5"
+      }
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "optional": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "optional": true
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "optional": true
+    },
+    "axios": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.15.3.tgz",
+      "integrity": "sha1-LJ1jiy4ZGgjqHWzJiOrda6W9wFM=",
+      "optional": true,
+      "requires": {
+        "follow-redirects": "1.0.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "bitsyntax": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/bitsyntax/-/bitsyntax-0.0.4.tgz",
+      "integrity": "sha1-6xDMb4K4xJDj6FaY8H6D1G4MuoI=",
+      "optional": true,
+      "requires": {
+        "buffer-more-ints": "0.0.2"
+      }
+    },
+    "bl": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+      "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+      "optional": true,
+      "requires": {
+        "readable-stream": "2.0.6"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "optional": true
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "optional": true
+        }
+      }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "optional": true
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "optional": true,
+      "requires": {
+        "hoek": "4.2.1"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "buffer-more-ints": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz",
+      "integrity": "sha1-JrOIXRD6E9t/wBquOquHAZngEkw="
+    },
+    "buildmail": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/buildmail/-/buildmail-4.0.1.tgz",
+      "integrity": "sha1-h393OLeHKYccmhBeO4N9K+EaenI=",
+      "optional": true,
+      "requires": {
+        "addressparser": "1.0.1",
+        "libbase64": "0.1.0",
+        "libmime": "3.0.0",
+        "libqp": "1.1.0",
+        "nodemailer-fetch": "1.6.0",
+        "nodemailer-shared": "1.1.0",
+        "punycode": "1.4.1"
+      }
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "optional": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "optional": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "optional": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "circular-json": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.1.tgz",
+      "integrity": "sha512-UjgcRlTAhAkLeXmDe2wK7ktwy/tgAqxiSndTIPiFZuIPLZmzHzWMwUIe9h9m/OokypG7snxCDEuwJshGBdPvaw=="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "optional": true
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "optional": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.5",
+        "typedarray": "0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "optional": true,
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "optional": true,
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        }
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "data-uri-to-buffer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
+      "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==",
+      "optional": true
+    },
+    "date-format": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",
+      "integrity": "sha1-YV6CjiM90aubua4JUODOzPpuytg="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "optional": true
+    },
+    "degenerator": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
+      "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
+      "optional": true,
+      "requires": {
+        "ast-types": "0.11.3",
+        "escodegen": "1.9.1",
+        "esprima": "3.1.3"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "depd": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+      "optional": true
+    },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
+      "optional": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "4.2.4"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "optional": true
+    },
+    "escodegen": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+      "optional": true,
+      "requires": {
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
+      }
+    },
+    "esprima": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "optional": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "optional": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "optional": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "optional": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "optional": true
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "requires": {
+        "pend": "1.2.0"
+      }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
+    "follow-redirects": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.0.0.tgz",
+      "integrity": "sha1-jjQpjL0uF28lTv/sdaHHjMhJ/Tc=",
+      "optional": true,
+      "requires": {
+        "debug": "2.6.9"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "optional": true
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "optional": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "ftp": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
+      "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
+      "optional": true,
+      "requires": {
+        "readable-stream": "1.1.14",
+        "xregexp": "2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "optional": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "optional": true
+        }
+      }
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "optional": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "optional": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "get-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.1.tgz",
+      "integrity": "sha512-7aelVrYqCLuVjq2kEKRTH8fXPTC0xKTkM+G7UlFkEwCXY3sFbSxvY375JoFowOAYbkaU47SrBvOefUlLZZ+6QA==",
+      "optional": true,
+      "requires": {
+        "data-uri-to-buffer": "1.2.0",
+        "debug": "2.6.9",
+        "extend": "3.0.1",
+        "file-uri-to-path": "1.0.0",
+        "ftp": "0.3.10",
+        "readable-stream": "2.3.5"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "optional": true
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "optional": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "optional": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "optional": true,
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
+      }
+    },
+    "hipchat-notifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hipchat-notifier/-/hipchat-notifier-1.1.0.tgz",
+      "integrity": "sha1-ttJJdVQ3wZEII2d5nTupoPI7Ix4=",
+      "optional": true,
+      "requires": {
+        "lodash": "4.17.5",
+        "request": "2.85.0"
+      }
+    },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+    },
+    "http-errors": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "optional": true,
+      "requires": {
+        "depd": "1.1.1",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.5.0"
+      }
+    },
+    "http-proxy-agent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz",
+      "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
+      "requires": {
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          }
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
+        }
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
+      }
+    },
+    "httpntlm": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
+      "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
+      "requires": {
+        "httpreq": "0.4.24",
+        "underscore": "1.7.0"
+      }
+    },
+    "httpreq": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz",
+      "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8="
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "4.2.1",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "optional": true
+    },
+    "inflection": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.10.0.tgz",
+      "integrity": "sha1-W//LEZetPoEFD44X4hZoCH7p6y8=",
+      "optional": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "optional": true
+    },
+    "is-my-json-valid": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+      "optional": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "optional": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "optional": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "optional": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "optional": true
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "optional": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "optional": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "optional": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "optional": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "libbase64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
+      "integrity": "sha1-YjUag5VjrF/1vSbxL2Dpgwu3UeY="
+    },
+    "libmime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-3.0.0.tgz",
+      "integrity": "sha1-UaGp50SOy9Ms2lRCFnW7IbwJPaY=",
+      "requires": {
+        "iconv-lite": "0.4.15",
+        "libbase64": "0.1.0",
+        "libqp": "1.1.0"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.15",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+          "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
+        }
+      }
+    },
+    "libqp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
+      "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g="
+    },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "optional": true
+    },
+    "log4js": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-2.5.3.tgz",
+      "integrity": "sha512-YL/qpTxYtK0iWWbuKCrevDZz5lh+OjyHHD+mICqpjnYGKdNRBvPeh/1uYjkKUemT1CSO4wwLOwphWMpKAnD9kw==",
+      "requires": {
+        "amqplib": "0.5.2",
+        "axios": "0.15.3",
+        "circular-json": "0.5.1",
+        "date-format": "1.2.0",
+        "debug": "3.1.0",
+        "hipchat-notifier": "1.1.0",
+        "loggly": "1.1.1",
+        "mailgun-js": "0.7.15",
+        "nodemailer": "2.7.2",
+        "redis": "2.8.0",
+        "semver": "5.5.0",
+        "slack-node": "0.2.0",
+        "streamroller": "0.7.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "loggly": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/loggly/-/loggly-1.1.1.tgz",
+      "integrity": "sha1-Cg/B0/o6XsRP3HuJe+uipGlc6+4=",
+      "optional": true,
+      "requires": {
+        "json-stringify-safe": "5.0.1",
+        "request": "2.75.0",
+        "timespan": "2.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "optional": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+          "optional": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "form-data": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
+          "integrity": "sha1-bwrrrcxdoWwT4ezBETfYX5uIOyU=",
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          }
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "optional": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "commander": "2.15.1",
+            "is-my-json-valid": "2.17.2",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "optional": true
+        },
+        "qs": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+          "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=",
+          "optional": true
+        },
+        "request": {
+          "version": "2.75.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
+          "integrity": "sha1-0rgmiihtoT6qXQGt9dGMyQ9lfZM=",
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "bl": "1.1.2",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.0.0",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "node-uuid": "1.4.8",
+            "oauth-sign": "0.8.2",
+            "qs": "6.2.3",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.4.3"
+          }
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "optional": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+          "optional": true
+        }
+      }
+    },
+    "lru-cache": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
+      "integrity": "sha1-5W1jVBSO3o13B7WNFDIg/QjfD9U=",
+      "optional": true
+    },
+    "mailcomposer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-4.0.1.tgz",
+      "integrity": "sha1-DhxEsqB890DuF9wUm6AJ8Zyt/rQ=",
+      "optional": true,
+      "requires": {
+        "buildmail": "4.0.1",
+        "libmime": "3.0.0"
+      }
+    },
+    "mailgun-js": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/mailgun-js/-/mailgun-js-0.7.15.tgz",
+      "integrity": "sha1-7jZqINrGTDwVwD1sGz4O15UlKrs=",
+      "optional": true,
+      "requires": {
+        "async": "2.1.5",
+        "debug": "2.2.0",
+        "form-data": "2.1.4",
+        "inflection": "1.10.0",
+        "is-stream": "1.1.0",
+        "path-proxy": "1.0.0",
+        "proxy-agent": "2.0.0",
+        "q": "1.4.1",
+        "tsscmp": "1.0.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "optional": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "optional": true
+        }
+      }
+    },
+    "mime": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "netmask": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
+      "optional": true
+    },
+    "nodemailer": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-2.7.2.tgz",
+      "integrity": "sha1-8kLmSa7q45tsftdA73sGHEBNMPk=",
+      "optional": true,
+      "requires": {
+        "libmime": "3.0.0",
+        "mailcomposer": "4.0.1",
+        "nodemailer-direct-transport": "3.3.2",
+        "nodemailer-shared": "1.1.0",
+        "nodemailer-smtp-pool": "2.8.2",
+        "nodemailer-smtp-transport": "2.7.2",
+        "socks": "1.1.9"
+      },
+      "dependencies": {
+        "socks": {
+          "version": "1.1.9",
+          "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz",
+          "integrity": "sha1-Yo1+TQSRJDVEWsC25Fk3bLPm1pE=",
+          "optional": true,
+          "requires": {
+            "ip": "1.1.5",
+            "smart-buffer": "1.1.15"
+          }
+        }
+      }
+    },
+    "nodemailer-direct-transport": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/nodemailer-direct-transport/-/nodemailer-direct-transport-3.3.2.tgz",
+      "integrity": "sha1-6W+vuQNYVglH5WkBfZfmBzilCoY=",
+      "optional": true,
+      "requires": {
+        "nodemailer-shared": "1.1.0",
+        "smtp-connection": "2.12.0"
+      }
+    },
+    "nodemailer-fetch": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz",
+      "integrity": "sha1-ecSQihwPXzdbc/6IjamCj23JY6Q="
+    },
+    "nodemailer-shared": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz",
+      "integrity": "sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=",
+      "requires": {
+        "nodemailer-fetch": "1.6.0"
+      }
+    },
+    "nodemailer-smtp-pool": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/nodemailer-smtp-pool/-/nodemailer-smtp-pool-2.8.2.tgz",
+      "integrity": "sha1-LrlNbPhXgLG0clzoU7nL1ejajHI=",
+      "optional": true,
+      "requires": {
+        "nodemailer-shared": "1.1.0",
+        "nodemailer-wellknown": "0.1.10",
+        "smtp-connection": "2.12.0"
+      }
+    },
+    "nodemailer-smtp-transport": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-2.7.2.tgz",
+      "integrity": "sha1-A9ccdjFPFKx9vHvwM6am0W1n+3c=",
+      "optional": true,
+      "requires": {
+        "nodemailer-shared": "1.1.0",
+        "nodemailer-wellknown": "0.1.10",
+        "smtp-connection": "2.12.0"
+      }
+    },
+    "nodemailer-wellknown": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz",
+      "integrity": "sha1-WG24EB2zDLRDjrVGc3pBqtDPE9U="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "optional": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "optional": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "pac-proxy-agent": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-1.1.0.tgz",
+      "integrity": "sha512-QBELCWyLYPgE2Gj+4wUEiMscHrQ8nRPBzYItQNOHWavwBt25ohZHQC4qnd5IszdVVrFbLsQ+dPkm6eqdjJAmwQ==",
+      "optional": true,
+      "requires": {
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1",
+        "get-uri": "2.0.1",
+        "http-proxy-agent": "1.0.0",
+        "https-proxy-agent": "1.0.0",
+        "pac-resolver": "2.0.0",
+        "raw-body": "2.3.2",
+        "socks-proxy-agent": "2.1.1"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+          "optional": true,
+          "requires": {
+            "agent-base": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
+        }
+      }
+    },
+    "pac-resolver": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-2.0.0.tgz",
+      "integrity": "sha1-mbiNLxk/ve78HJpSnB8yYKtSd80=",
+      "optional": true,
+      "requires": {
+        "co": "3.0.6",
+        "degenerator": "1.0.4",
+        "ip": "1.0.1",
+        "netmask": "1.0.6",
+        "thunkify": "2.1.2"
+      },
+      "dependencies": {
+        "co": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/co/-/co-3.0.6.tgz",
+          "integrity": "sha1-FEXyJsXrlWE45oyawwFn6n0ua9o=",
+          "optional": true
+        },
+        "ip": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.0.1.tgz",
+          "integrity": "sha1-x+NWzeoiWucbNtcPLnGpK6TkJZA=",
+          "optional": true
+        }
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-proxy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-proxy/-/path-proxy-1.0.0.tgz",
+      "integrity": "sha1-GOijaFn8nS8aU7SN7hOFQ8Ag3l4=",
+      "optional": true,
+      "requires": {
+        "inflection": "1.3.8"
+      },
+      "dependencies": {
+        "inflection": {
+          "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.3.8.tgz",
+          "integrity": "sha1-y9Fg2p91sUw8xjV41POWeEvzAU4=",
+          "optional": true
+        }
+      }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "optional": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "optional": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "optional": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+    },
+    "proxy-agent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.0.0.tgz",
+      "integrity": "sha1-V+tTR6qAXXTsaByyVknbo5yTNJk=",
+      "optional": true,
+      "requires": {
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1",
+        "http-proxy-agent": "1.0.0",
+        "https-proxy-agent": "1.0.0",
+        "lru-cache": "2.6.5",
+        "pac-proxy-agent": "1.1.0",
+        "socks-proxy-agent": "2.1.1"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+          "optional": true,
+          "requires": {
+            "agent-base": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
+        }
+      }
+    },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "optional": true
+    },
+    "puppeteer": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.6.1.tgz",
+      "integrity": "sha512-qz6DLwK+PhlBMjJZOMOsgVCnweYLtmiqnmJYUDPT++ElMz+cQgbsCNKPw4YDVpg3RTbsRX/pqQqr20zrp0cuKw==",
+      "requires": {
+        "debug": "3.1.0",
+        "extract-zip": "1.6.7",
+        "https-proxy-agent": "2.2.1",
+        "mime": "2.3.1",
+        "progress": "2.0.0",
+        "proxy-from-env": "1.0.0",
+        "rimraf": "2.6.2",
+        "ws": "5.2.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "q": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+      "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+      "optional": true
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "optional": true
+    },
+    "raw-body": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "optional": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "redis": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "optional": true,
+      "requires": {
+        "double-ended-queue": "2.1.0-0",
+        "redis-commands": "1.3.5",
+        "redis-parser": "2.6.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.5.tgz",
+      "integrity": "sha512-foGF8u6MXGFF++1TZVC6icGXuMYPftKXt1FBT2vrfU9ZATNtZJ8duRC5d1lEfE8hyVe3jhelHGB91oB7I6qLsA==",
+      "optional": true
+    },
+    "redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=",
+      "optional": true
+    },
+    "request": {
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "optional": true,
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
+      }
+    },
+    "requestretry": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.13.0.tgz",
+      "integrity": "sha512-Lmh9qMvnQXADGAQxsXHP4rbgO6pffCfuR8XUBdP9aitJcLQJxhp7YZK4xAVYXnPJ5E52mwrfiKQtKonPL8xsmg==",
+      "optional": true,
+      "requires": {
+        "extend": "3.0.1",
+        "lodash": "4.17.5",
+        "request": "2.85.0",
+        "when": "3.7.8"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+    },
+    "setprototypeof": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+      "optional": true
+    },
+    "slack-node": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/slack-node/-/slack-node-0.2.0.tgz",
+      "integrity": "sha1-3kuN3aqLeT9h29KTgQT9q/N9+jA=",
+      "optional": true,
+      "requires": {
+        "requestretry": "1.13.0"
+      }
+    },
+    "smart-buffer": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+      "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
+    },
+    "smtp-connection": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz",
+      "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME=",
+      "requires": {
+        "httpntlm": "1.6.1",
+        "nodemailer-shared": "1.1.0"
+      }
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "optional": true,
+      "requires": {
+        "hoek": "4.2.1"
+      }
+    },
+    "socks": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.10.tgz",
+      "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
+      "requires": {
+        "ip": "1.1.5",
+        "smart-buffer": "1.1.15"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-2.1.1.tgz",
+      "integrity": "sha512-sFtmYqdUK5dAMh85H0LEVFUCO7OhJJe1/z2x/Z6mxp3s7/QPf1RkZmpZy+BpuU0bEjcV9npqKjq9Y3kwFUjnxw==",
+      "requires": {
+        "agent-base": "2.1.1",
+        "extend": "3.0.1",
+        "socks": "1.1.10"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+          "requires": {
+            "extend": "3.0.1",
+            "semver": "5.0.3"
+          }
+        },
+        "semver": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no="
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "optional": true
+    },
+    "sshpk": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "optional": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "optional": true
+    },
+    "streamroller": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.7.0.tgz",
+      "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
+      "requires": {
+        "date-format": "1.2.0",
+        "debug": "3.1.0",
+        "mkdirp": "0.5.1",
+        "readable-stream": "2.3.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "optional": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "optional": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "optional": true
+    },
+    "thunkify": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
+      "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=",
+      "optional": true
+    },
+    "timespan": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/timespan/-/timespan-2.3.0.tgz",
+      "integrity": "sha1-SQLOBAvRPYRcj1myfp1ZutbzmSk=",
+      "optional": true
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "optional": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tsscmp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
+      "integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc=",
+      "optional": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "optional": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "optional": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "optional": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    },
+    "when": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
+      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I=",
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "optional": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "requires": {
+        "async-limiter": "1.0.0"
+      }
+    },
+    "xregexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
+      "optional": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "optional": true
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "requires": {
+        "fd-slicer": "1.0.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,13 +1,18 @@
 {
-	"name": "mShots.JS",
+	"name": "mShots.NodeJS",
 	"author": "David Newman <dnewman@automattic.com>",
-	"description": "WordPress mShots System Service (node.js version)",
+	"description": "WordPress mShots System",
 	"version": "0.1.0",
 	"main": "./lib/mshots.js",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/automattic/mshots.git"
+	},
 	"engines": {
-		"node": ">= 0.10.0"
+		"node": ">= 8.0.0"
 	},
 	"dependencies": {
-    		"log4js": ">=0.6.0"
-  	}
+		"log4js": ">=0.6.0",
+		"puppeteer": "^1.6.1"
+	}
 }

--- a/public_html/class-mshots.php
+++ b/public_html/class-mshots.php
@@ -241,7 +241,7 @@ if ( ! class_exists( 'mShots' ) ) {
 
 		private function my307( $redirect_url ) {
 			header( "HTTP/1.1 307 Temporary Redirect" );
-			header( "Last-Modified, 01 Jan 2013 01:00:00 GMT" );
+			header( "Last-Modified: Tue, 01 Jan 2013 01:00:00 GMT" );
 			header( "Expires: " . gmdate( 'D, d M Y H:i:s' ) . " GMT" );
 			header( "Cache-Control: no-cache, no-store, must-revalidate, max-age=0, pre-check=1, post-check=2" );
 			header( "Pragma: no-cache" );

--- a/public_html/class-mshots.php
+++ b/public_html/class-mshots.php
@@ -8,7 +8,8 @@ if ( ! class_exists( 'mShots' ) ) {
 		const disable_requeue = false;
 		const location_header = 'X-Accel-Redirect: ';
 		const location_base = '/opt/mshots/public_html/thumbnails';
-		const snapshot_default = 'https://s0.wp.com/wp-content/plugins/mshots/default.gif';
+		const snapshot_default = 'https://s0.wp.com/mshots/v1/default';
+		const snapshot_default_file = '/opt/mshots/public_html/images/default.gif';
 
 		const VIEWPORT_MAX_W = 1600;
 		const VIEWPORT_MAX_H = 1200;
@@ -42,6 +43,10 @@ if ( ! class_exists( 'mShots' ) ) {
 
 			if ( 2 > count( $array_check ) || $array_check[1] != 'v1' )
 				$this->my404();
+
+			if ( 'default' == $array_check[2] ) {
+				$this->serve_default_gif();
+			}
 
 			if ( ( isset( $_GET[ 'requeue' ] ) && "true" == $_GET[ 'requeue' ] ) ) {
 				$this->requeue = true;
@@ -229,6 +234,16 @@ if ( ! class_exists( 'mShots' ) ) {
 				error_log( "error processing filename : " . $image_filename );
 				$this->my404();
 			}
+		}
+
+		private function serve_default_gif() {
+			header( "HTTP/1.1 200 OK" );
+			header( 'Content-Length: ' . filesize( self::snapshot_default_file ) );
+			header( 'Content-Type: image/gif' );
+			header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', time() ) . ' GMT' );
+			header( "Expires: " . gmdate( 'D, d M Y H:i:s', time() + 63115200 ) . " GMT" );
+			readfile( self::snapshot_default_file );
+			die();
 		}
 
 		private function my404() {


### PR DESCRIPTION
This change-set switches from using the custom Qt C++ node backend module to `puppeteer` to render the snapshots.

* Add Node.js 8.x and puppeteer requirements to `package.json`, as well `package-lock.json`.
* Added blacklist module to reproduce the Qt C++ class.
* Switched to the new `log4js` module's config setting format.