### PR TITLE
Testing full browser screenshots

### DIFF
--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -102,7 +102,7 @@ function take_snapshot( p_uri, p_filename, p_width, p_height ) {
 		await page.setRequestInterception( true );
 		await page._client.send( 'Page.setDownloadBehavior', { behavior: 'deny' } );
 
-		page.setViewport( { width: p_width, height: p_height } );
+		page.setViewport( { width: 0, height: 0 } );
 
 		await page.on( 'request', request => {
 			if ( 0 < block_all_code ) {
@@ -185,7 +185,7 @@ function take_snapshot( p_uri, p_filename, p_width, p_height ) {
 		if ( response && response.ok() || page_loaded ) {
 			await page.waitFor( 2000 );
 			makeDirIfRequired( _path.dirname( p_filename ) );
-			await page.screenshot( { path: p_filename, fullPage: false, type: 'jpeg', quality: 90 } );
+			await page.screenshot( { path: p_filename, fullPage: true, type: 'jpeg', quality: 90 } );
 			await page.close();
 			logger.debug( process.pid + ': snapped: ' + p_uri );
 


### PR DESCRIPTION

Testing if it's possible to grab a full browser screenshot with these values. See https://github.com/Automattic/mShots/issues/16

This is just a test; we'd somehow pass values via URL arguments in reality.

![full-browser-example](https://user-images.githubusercontent.com/87168/78031341-1d181080-736c-11ea-88a4-d3cb3e8e90bb.jpg)
 