### PR TITLE
Try: More Parameters

### DIFF
--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -61,8 +61,16 @@ function init_browser() {
 	})();
 }
 
-function take_snapshot( p_uri, p_filename, p_width, p_height ) {
-	let m_uri = p_uri;
+function take_snapshot( p_all ) {
+	const {
+		url,
+		file: p_filename,
+		width: p_width = 600,
+		height: p_height = 800,
+		fullPage: p_fullPage = false,
+		clip: p_clip = null
+	} = p_all;
+	let m_uri = url;
 	if ( ! m_uri.match( /^([a-z][a-z0-9+\-.]*):/i ) ) {
 		m_uri = 'http://' + m_uri;
 	}
@@ -72,13 +80,13 @@ function take_snapshot( p_uri, p_filename, p_width, p_height ) {
 		saveAs( 404, p_filename );
 		time_downloading = 0;
 		downloading = false;
-		logger.error( process.pid + ': Invalid URL: ' + p_uri + '. Saved as 404 and continued with queue.' );
+		logger.error( process.pid + ': Invalid URL: ' + url + '. Saved as 404 and continued with queue.' );
 		process.send({
 			replytype: 'queue-del',
 			workerid: process.pid,
 			payload: {
 				status: ( ! parsedUri.host ? HOST_INVALID : HOST_INVALIDSCHEMA ),
-				url   : p_uri,
+				url   : url,
 				file  : p_filename,
 			}
 		});
@@ -151,7 +159,7 @@ function take_snapshot( p_uri, p_filename, p_width, p_height ) {
 				redirect_count++;
 				redirect_uri = response.headers().location;
 				if ( redirect_count > REDIRECT_LIMIT ) {
-					logger.error( process.pid + ': redirect limit for ' + p_uri + ' reached at ', redirect_uri );
+					logger.error( process.pid + ': redirect limit for ' + url + ' reached at ', redirect_uri );
 					block_all_code = GENERAL_ERROR;
 				}
 			}
@@ -185,9 +193,11 @@ function take_snapshot( p_uri, p_filename, p_width, p_height ) {
 		if ( response && response.ok() || page_loaded ) {
 			await page.waitFor( 2000 );
 			makeDirIfRequired( _path.dirname( p_filename ) );
-			await page.screenshot( { path: p_filename, fullPage: false, type: 'jpeg', quality: 90 } );
+			// await page.screenshot( { path: p_filename, fullPage: true, type: 'jpeg', quality: 90 } );
+
+			await page.screenshot( { path: p_filename, fullPage: p_fullPage, type: 'jpeg', quality: 90, ...( p_fullPage ? {} : { clip: p_clip } ) } );
 			await page.close();
-			logger.debug( process.pid + ': snapped: ' + p_uri );
+			logger.debug( process.pid + ': snapped: ' + url );
 
 			let pages = await browser.pages();
 			pages.forEach( function( p ) {
@@ -199,7 +209,7 @@ function take_snapshot( p_uri, p_filename, p_width, p_height ) {
 				workerid: process.pid,
 				payload: {
 					status: SUCCESS,
-					url   : p_uri,
+					url   : url,
 					file  : p_filename,
 				}
 			});
@@ -220,25 +230,25 @@ function take_snapshot( p_uri, p_filename, p_width, p_height ) {
 		switch ( status ) {
 			case 0:
 				saveAs( 404, p_filename );
-				logger.error( process.pid + ': Timed out loading ' + p_uri + '. Saved as 404.' );
+				logger.error( process.pid + ': Timed out loading ' + url + '. Saved as 404.' );
 				break;
 			case 401:
 				saveAs( 401, p_filename );
-				logger.error( process.pid + ': Failed to load ' + p_uri + '. Authentication required.' );
+				logger.error( process.pid + ': Failed to load ' + url + '. Authentication required.' );
 				break;
 			case 403:
 				saveAs( 403, p_filename );
-				logger.error( process.pid + ': Failed to load ' + p_uri + '. Access denied.' );
+				logger.error( process.pid + ': Failed to load ' + url + '. Access denied.' );
 				break;
 			case 415:
-				logger.error( process.pid + ': Failed to load ' + p_uri + '. Unsupported content.' );
+				logger.error( process.pid + ': Failed to load ' + url + '. Unsupported content.' );
 				break;
 			case 400:
 			case 404:
 			case 500:
 			default:
 				saveAs( 404, p_filename );
-				logger.error( process.pid + ': Failed to load ' + p_uri + '. Saved as 404.' );
+				logger.error( process.pid + ': Failed to load ' + url + '. Saved as 404.' );
 				break;
 		}
 
@@ -247,7 +257,7 @@ function take_snapshot( p_uri, p_filename, p_width, p_height ) {
 			workerid: process.pid,
 			payload: {
 				status: ( 0 < block_all_code ? block_all_code : GENERAL_ERROR ),
-				url   : p_uri,
+				url   : url,
 				file  : p_filename,
 			}
 		});
@@ -347,10 +357,13 @@ function check_site_queue() {
 			downloading = true;
 			logger.debug( process.pid + ': site queue size = ' + site_queue.length );
 
-			var s_details = site_queue[0];
+			var s_details = {
+				fullPage: false,
+				...site_queue[0],
+			}
 			site_queue.shift();
 			logger.debug( process.pid + ': snapping: ' + s_details.url );
-			take_snapshot( s_details.url, s_details.file, s_details.width, s_details.height );
+			take_snapshot( s_details );
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"node": ">= 8.0.0"
 	},
 	"dependencies": {
+		"ip": "^1.1.5",
 		"log4js": ">=0.6.0",
 		"puppeteer": "^1.6.1"
 	}


### PR DESCRIPTION
We'd like to use mShots to dynamically generate preview screenshots in gutenboarding and it's looking great in general but there are a few themes that look pretty odd (see https://github.com/Automattic/wp-calypso/pull/43428).

This PR is to discuss enabling more parameters to pass to puppeteer as a mechanism to solve those problems. I'm just dumping exploratory code here, but if I can get some agreement that this is the right way to go I'll tidy this up and extend the changes up to the API.

I'm working on OSX, so I don't have the kernel extensions required to run the mshots service, so I've just been running the snapshot lib directly. After cloning mshots into `/opt/local` and running `npm install` as per the instructions, I've been testing using:

```
node --experimental-repl-await
snapshot = require('./lib/snapshot')
await snapshot.init_browser()
test_url = 'https://public-api.wordpress.com/rest/v1/template/demo/rockfield/rockfield?font_headings=Playfair%20Display&font_base=Fira%20Sans&site_title=Rockfield'
// shim because snapshot expects to be a child process
process.send = process.send || ((...args) => console.log(...args))
snapshot.add_to_queue( { width: 1200, height: 3072, url: test_url, file: 'test.jpg', })
```

This takes a moment before it dumps the reply object, and then you can `open /opt/mshots/test.jpg` to see the image.

In particular, I've been looking at the [Rockfield theme](https://rockfielddemo.wordpress.com/?theme_preview=true). It's got that cool effect where the background images change as the text wipes through them:

![Rockfield-theme](https://user-images.githubusercontent.com/5952255/86086518-479d7500-bae5-11ea-9f10-57b410e2b86c.gif)

Unfortunately, the theme gets a bit confused when the viewport is big enough to get an impression of the theme:

`snapshot.add_to_queue( { width: 1200, height: 3072, url: test_url, file: 'test.jpg', })`

Each picture is being scaled to fill the entire scrollHeight, instead of the smaller viewport we'd see while scrolling through, so the first picture ends up being a ![picture of a giant hand](https://user-images.githubusercontent.com/5952255/86086900-2c7f3500-bae6-11ea-8393-dd00d191077c.jpg)

Now, there is an argument to be made that we could/should fix the css, but it's not really just another screen size to push on designers because we want different behaviour for this one, so I spent some time seeing if I could persuade puppeteer to play nice, and I found the clip parameter:

<img src="https://user-images.githubusercontent.com/5952255/86087507-b7acfa80-bae7-11ea-9102-7c79bfe2c107.jpg" height="800px"></img>

You can see that this is not perfect, as there's no image behind "Discover Our Menu", but it seems much better to me in this specific instance, and much more intuitive in general - we can keep the viewport parameters in typical sane ranges and use the clip parameters to "scroll down" instead.

I also checked out the 'fullPage' option, but it wasn't what I needed, but I saw someone ask for it so I thought I'd include it here:

snapshot.add_to_queue( { fullPage: true, url: test_url + '&viewport_height=700', file: 'test.jpg' } )
![full-page](https://user-images.githubusercontent.com/5952255/86087999-cc3dc280-bae8-11ea-83b7-296e5277d466.jpg)

Note that here we need the preview viewport hack on the website itself to get halfway reasonable result, otherwise the whole picture is just the giant hand with a little text at the bottom. I think the fact that we don't need that hack if we use the clip parameters instead is a really good sign that it's the right way to go.