### PR TITLE
Try: Add a quality query param to optionally set jpeg quality to a low or medium value

### DIFF
--- a/public_html/class-mshots.php
+++ b/public_html/class-mshots.php
@@ -25,6 +25,7 @@ if ( ! class_exists( 'mShots' ) ) {
 		private $invalidate = false;
 		private $viewport_w = self::VIEWPORT_DEFAULT_W;
 		private $viewport_h = self::VIEWPORT_DEFAULT_H;
+		private $quality = '';
 
 		function __construct() {
 			ob_start();
@@ -82,6 +83,15 @@ if ( ! class_exists( 'mShots' ) ) {
 					$this->viewport_h = self::VIEWPORT_MAX_H;
 				else if ( $this->viewport_h < self::VIEWPORT_MIN_H )
 					$this->viewport_h = self::VIEWPORT_MIN_H;
+			}
+
+			if ( isset( $_GET[ 'quality' ] ) ) {
+				if ( 'low' === $_GET[ 'quality' ] ) {
+					$this->quality = 'low';
+				}
+				if ( 'med' === $_GET[ 'quality' ] ) {
+					$this->quality = 'med';
+				}
 			}
 
 			$this->snapshot_file = $this->resolve_filename( $this->snapshot_url );
@@ -201,7 +211,13 @@ if ( ! class_exists( 'mShots' ) ) {
 					if ( $thumb_height < 20 ) $thumb_height = 20;
 					$thumb_aspect = $thumb_width / $thumb_height;
 					if ( ( $thumb_width == $width &&  $thumb_height == $height ) ) {
-						imagejpeg( $image, null, 90 );
+						if ( $this->quality === 'low' ) {
+							imagejpeg( $image, null, 50 );
+						} else if ( $this->quality === 'med' ) {
+							imagejpeg( $image, null, 72 );
+						} else {
+							imagejpeg( $image, null, 90 );
+						}
 					} else {
 						if ( $original_aspect >= $thumb_aspect ) {
 							$new_height = $thumb_height;
@@ -213,7 +229,13 @@ if ( ! class_exists( 'mShots' ) ) {
 						$thumb = imagecreatetruecolor( $thumb_width, $thumb_height );
 						$indentX = 0 - ( $new_width - $thumb_width ) / 2;
 						imagecopyresampled( $thumb, $image, $indentX, 0, 0, 0, $new_width, $new_height, $width, $height );
-						imagejpeg( $thumb, null, 95 );
+						if ( $this->quality === 'low' ) {
+							imagejpeg( $image, null, 50 );
+						} else if ( $this->quality === 'med' ) {
+							imagejpeg( $image, null, 72 );
+						} else {
+							imagejpeg( $image, null, 95 );
+						}
 					}
 				} else {
 					error_log( "error processing filename : " . $image_filename );
@@ -273,9 +295,18 @@ if ( ! class_exists( 'mShots' ) ) {
 			$host = sha1( strtolower( $s_host ) );
 			$file = md5( $snap_url );
 			$viewport = '';
-			if ( $this->viewport_w != self::VIEWPORT_DEFAULT_W || $this->viewport_h != self::VIEWPORT_DEFAULT_H )
+
+			if ( $this->viewport_w != self::VIEWPORT_DEFAULT_W || $this->viewport_h != self::VIEWPORT_DEFAULT_H ) {
 				$viewport = '_' . $this->viewport_w . 'x' . $this->viewport_h;
-			$fullpath = self::location_base . '/' . substr( $host, 0, 3 ) . '/' . $host . '/' . $file . $viewport. '.jpg';
+			}
+
+			$quality = '';
+
+			if ( $this->quality ) {
+				$quality = '_' . $this->quality;
+			}
+
+			$fullpath = self::location_base . '/' . substr( $host, 0, 3 ) . '/' . $host . '/' . $file . $viewport . $quality . '.jpg';
 
 			return $fullpath;
 		}


### PR DESCRIPTION
WIP: Note this has not been manually tested.

This a speculative attempt to add a `low` and `medium` quality option to mshots when saving out the JPEG image (I've selected `50` and `72` as values, but these could be changed).

The use case here is for if we need to display a larger number of screenshots on a particular page, we might wish to use lower quality images at a higher resolution, to optimise image loading. Or, use a small, low quality image in an initial page load before swapping out for a higher quality image. The purpose here is to give us the flexibility to be able have images with smaller file sizes.

## Changes proposed

Add a `quality` query param to the PHP to support setting a `med` or `low` image quality on the requested JPEG image.

## To do

* [ ] Check that this does not affect caching / cache busting for any existing generated images
* [ ] Adding the `quality=med` param should give you a unique filename with the quality in the name of the file, and this should be a unique cache key, too
* [ ] Test that the proposed values are desirable
* [ ] Test manually to make sure this actually works (I started exploring a local dev environment in #22, but haven't gotten that working yet)
* [ ] Anything else?