### PR TITLE
Adds thumbnails-permanent for specific host

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -71,9 +71,17 @@ function validateFileName( request ) {
 
 	let s_filename = _cypher.createHash( 'md5' ).update( request.url ).digest( 'hex' ) + viewport + '.jpg';
 	let s_host = _cypher.createHash( 'sha1' ).update( host ).digest( 'hex' );
-	let s_fullpath = '/opt/mshots/public_html/thumbnails/' + s_host.substring( 0, 3 ) + "/" + s_host + "/" + s_filename;
+	let s_fullpath = getPath( host ) + s_host.substring( 0, 3 ) + "/" + s_host + "/" + s_filename;
 
 	return ( s_fullpath == request.file );
+}
+
+function getPath( host ) {
+	logger.error( 'getPath host: ' + host );
+	if ( 'public-api.wordpress.com' === host ) {
+		return '/opt/mshots/public_html/thumbnails-permanent/'; 
+	}
+	return '/opt/mshots/public_html/thumbnails/';
 }
 
 var HTTPListner = function() {
@@ -124,7 +132,7 @@ var HTTPListner = function() {
 				}
 
 				if ( ! validateFileName( site ) ) {
-					logger.error( process.pid + ': invalid filename: validation failed' );
+					logger.error( process.pid + ': invalid filename: validation failed :' + site );
 				} else {
 					process.send( { replytype: 'queue-add', workerid: process.pid, payload: site } );
 				}

--- a/public_html/class-mshots.php
+++ b/public_html/class-mshots.php
@@ -8,6 +8,7 @@ if ( ! class_exists( 'mShots' ) ) {
 		const disable_requeue = false;
 		const location_header = 'X-Accel-Redirect: ';
 		const location_base = '/opt/mshots/public_html/thumbnails';
+		const permanent_base = '/opt/mshots/public_html/thumbnails-permanent';
 		const snapshot_default = 'https://s0.wp.com/mshots/v1/default';
 		const snapshot_default_file = '/opt/mshots/public_html/images/default.gif';
 
@@ -278,9 +279,16 @@ if ( ! class_exists( 'mShots' ) ) {
 			$viewport = '';
 			if ( $this->viewport_w != self::VIEWPORT_DEFAULT_W || $this->viewport_h != self::VIEWPORT_DEFAULT_H )
 				$viewport = '_' . $this->viewport_w . 'x' . $this->viewport_h;
-			$fullpath = self::location_base . '/' . substr( $host, 0, 3 ) . '/' . $host . '/' . $file . $viewport. '.jpg';
+			$fullpath = $this->get_base( $s_host ) . '/' . substr( $host, 0, 3 ) . '/' . $host . '/' . $file . $viewport. '.jpg';
 
 			return $fullpath;
+		}
+
+		private function get_base( $host ) {
+			if ( 'public-api.wordpress.com' === $host ) {
+				return self::permanent_base;
+			}
+			return self::location_base;
 		}
 
 		private function resolve_mshots_url( $url ) {


### PR DESCRIPTION
I am not sure if this is the right approach here. 

The problem that I am trying to solve it make sure that under some domains (that we control such as public-api.wordpress.com) we don't clear the cache and are always able to serve an image. 

