### PR TITLE
Add phpunit tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Run JavaScript tests
+name: Run JavaScript & PHP tests
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -42,3 +42,11 @@ Control the execution of the application with the `mshots_ctl.sh` bash script in
 
 	> node lib/mshots -p <port number> -n <number of workers>
 
+
+Tests
+------
+
+Both JS and php unit tests live in the `tests` directory and can be run with
+the `npm test` command.
+
+They can also be run individually with `npm run test:js` and `npm run test:php`

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	},
 	"scripts": {
 		"test": "npm run test:php && npm run test:js",
-		"test:php": "phpunit tests",
+		"test:php": "phpunit -c tests/phpunit.xml tests",
 		"test:js": "jest"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
 		"node": ">= 8.0.0"
 	},
 	"scripts": {
-		"test": "jest"
+		"test": "npm run test:php && npm run test:js",
+		"test:php": "phpunit tests",
+		"test:js": "jest"
 	},
 	"dependencies": {
 		"ip": "^1.1.5",

--- a/public_html/class-mshots.php
+++ b/public_html/class-mshots.php
@@ -18,13 +18,13 @@ if ( ! class_exists( 'mShots' ) ) {
 		const VIEWPORT_DEFAULT_W = 1280;
 		const VIEWPORT_DEFAULT_H = 960;
 
-		private $snapshot_url = "";
-		private $snapshot_file = "";
-		private $parsed_url = "";
-		private $requeue = false;
-		private $invalidate = false;
-		private $viewport_w = self::VIEWPORT_DEFAULT_W;
-		private $viewport_h = self::VIEWPORT_DEFAULT_H;
+		protected $snapshot_url = "";
+		protected $snapshot_file = "";
+		protected $parsed_url = "";
+		protected $requeue = false;
+		protected $invalidate = false;
+		protected $viewport_w = self::VIEWPORT_DEFAULT_W;
+		protected $viewport_h = self::VIEWPORT_DEFAULT_H;
 
 		function __construct() {
 			ob_start();
@@ -236,7 +236,7 @@ if ( ! class_exists( 'mShots' ) ) {
 			}
 		}
 
-		private function serve_default_gif() {
+		protected function serve_default_gif() {
 			header( "HTTP/1.1 200 OK" );
 			header( 'Content-Length: ' . filesize( self::snapshot_default_file ) );
 			header( 'Content-Type: image/gif' );
@@ -246,7 +246,7 @@ if ( ! class_exists( 'mShots' ) ) {
 			die();
 		}
 
-		private function my404() {
+		protected function my404() {
 			header( "Content-Type: text/plain" );
 			header( "HTTP/1.1 404 Not Found" );
 			header( "Last-Modified: " . gmdate( 'D, d M Y H:i:s', 1) . " GMT" );
@@ -254,7 +254,7 @@ if ( ! class_exists( 'mShots' ) ) {
 			die( "HTTP/1.1 404 Not Found" );
 		}
 
-		private function my307( $redirect_url ) {
+		protected function my307( $redirect_url ) {
 			header( "HTTP/1.1 307 Temporary Redirect" );
 			header( "Last-Modified: Tue, 01 Jan 2013 01:00:00 GMT" );
 			header( "Expires: " . gmdate( 'D, d M Y H:i:s' ) . " GMT" );
@@ -264,7 +264,7 @@ if ( ! class_exists( 'mShots' ) ) {
 			header( "Content-Type: text/html; charset=UTF-8" );
 		}
 
-		private function resolve_filename( $snap_url ) {
+		protected function resolve_filename( $snap_url ) {
 			$url_parts = explode( '://', $snap_url );
 			if ( 1 < count( $url_parts ) )
 				$s_host = explode( '/', $url_parts[1] )[0];
@@ -280,14 +280,14 @@ if ( ! class_exists( 'mShots' ) ) {
 			return $fullpath;
 		}
 
-		private function resolve_mshots_url( $url ) {
+		protected function resolve_mshots_url( $url ) {
 			return sprintf(
 				"/mshots/v1/%s",
 				rawurlencode( $url )
 				);
 		}
 
-		private function invalidate_snapshot( $snapshot_url ) {
+		protected function invalidate_snapshot( $snapshot_url ) {
 			$uri = str_replace( '&requeue=true', '', $_SERVER['REQUEST_URI'] );
 			$uri = str_replace( '?requeue=true', '', $uri );
 			$this->purge_snapshot( $uri );

--- a/tests/MshotsTest.php
+++ b/tests/MshotsTest.php
@@ -6,6 +6,9 @@ class TestMshots extends mShots {
 	//
 	// Stubs to avoid calls to die()
 	//
+	public $served_404 = false;
+	public $served_default_gif = false;
+
 	public function serve_default_gif() {
 		$this->served_default_gif = true;
 	}
@@ -63,7 +66,7 @@ class MshotsTest extends \PHPUnit\Framework\TestCase {
 
 	public function uri_and_filenames() {
 		return [
-			[ '/invalid', '404' ],
+			[ '/mshots/invalid/http://example.com', '404' ],
 			[ '/mshots/v1/default', 'default' ],
 			[ '/mshots/v1/https://public-api.wordpress.com/rest/v1/template/demo/rockfield/reynolds?font_base=Fira%20Sans&font_headings=Playfair%20Display&site_title=Reynolds&language=ko',
 			 '/opt/mshots/public_html/thumbnails/ed2/ed271f0f0255e9d784e345dc2f0d8cc48ca26019/e295c5f761af9ac029f49726f50b16b1.jpg' ]

--- a/tests/MshotsTest.php
+++ b/tests/MshotsTest.php
@@ -1,0 +1,7 @@
+<?php
+
+class MshotsTest extends \PHPUnit\Framework\TestCase {
+	public function test_test() {
+		$this->assertTrue( false );
+	}
+}

--- a/tests/MshotsTest.php
+++ b/tests/MshotsTest.php
@@ -78,8 +78,4 @@ class MshotsTest extends \PHPUnit\Framework\TestCase {
 			[ '/mshots/v1/http%3A%2F%2Fcentrodelahoya.es', '/opt/mshots/public_html/thumbnails/9c2/9c2aba28f0d90f31dace1cf44f078ef8a084f07b/b633ca3b16327c692df17133f00d6554.jpg' ]
 		];
 	}
-
-    public function test_test() {
-		$this->assertTrue( false );
-    }
 }

--- a/tests/MshotsTest.php
+++ b/tests/MshotsTest.php
@@ -69,7 +69,13 @@ class MshotsTest extends \PHPUnit\Framework\TestCase {
 			[ '/mshots/invalid/http://example.com', '404' ],
 			[ '/mshots/v1/default', 'default' ],
 			[ '/mshots/v1/https://public-api.wordpress.com/rest/v1/template/demo/rockfield/reynolds?font_base=Fira%20Sans&font_headings=Playfair%20Display&site_title=Reynolds&language=ko',
-			 '/opt/mshots/public_html/thumbnails/ed2/ed271f0f0255e9d784e345dc2f0d8cc48ca26019/e295c5f761af9ac029f49726f50b16b1.jpg' ]
+			 '/opt/mshots/public_html/thumbnails/ed2/ed271f0f0255e9d784e345dc2f0d8cc48ca26019/e295c5f761af9ac029f49726f50b16b1.jpg' ],
+			// A couple of examples from a google search:
+			[ '/mshots/v1/http%3A%2F%2Fcreatemockup.com%2F?w=250', '/opt/mshots/public_html/thumbnails/08b/08bcf1d9cc9648502091e6d3e4738cb87e410391/598882683350e71c7f0803b28f2d4089.jpg' ],
+			// https://shkspr.mobi/blog/2018/12/using-the-wordpress-mshots-screenshot-api/
+			[ '/mshots/v1/https%3A%2F%2Ftwitter.com%2FJennyVass%2Fstatus%2F1067855777040338944?w=800', '/opt/mshots/public_html/thumbnails/465/465806fbb3547c258cfa20becfef6e08f41c233b/3bdc1867dd156a7c3d63a894557592bc.jpg' ],
+			// A gravatar example:
+			[ '/mshots/v1/http%3A%2F%2Fcentrodelahoya.es', '/opt/mshots/public_html/thumbnails/9c2/9c2aba28f0d90f31dace1cf44f078ef8a084f07b/b633ca3b16327c692df17133f00d6554.jpg' ]
 		];
 	}
 

--- a/tests/MshotsTest.php
+++ b/tests/MshotsTest.php
@@ -1,7 +1,76 @@
 <?php
 
-class MshotsTest extends \PHPUnit\Framework\TestCase {
-	public function test_test() {
-		$this->assertTrue( false );
+require_once dirname( __DIR__ ) . '/public_html/class-mshots.php';
+
+class TestMshots extends mShots {
+	//
+	// Stubs to avoid calls to die()
+	//
+	public function serve_default_gif() {
+		$this->served_default_gif = true;
 	}
+
+	public function my404() {
+		$this->served_404 = true;
+	}
+
+	//
+	// Getters to expose (carefully considered) private variables to tests
+	//
+	public function get_snapshot_url() {
+		return $this->snapshot_url;
+	}
+
+	public function get_parsed_url() {
+		return $this->parsed_url;
+	}
+
+	public function get_snapshot_file() {
+		return $this->snapshot_file;
+	}
+
+	//
+	// Convenience function to coerce statuses for dataProvider
+	//
+	public function status_string_or_value( $value ) {
+		if ( $this->served_404 ) {
+			return '404';
+		}
+
+		if ( $this->served_default_gif ) {
+			return 'default';
+		}
+
+		return $this->$value;
+	}
+}
+
+class MshotsTest extends \PHPUnit\Framework\TestCase {
+	/**
+	 * @dataProvider uri_and_filenames
+	 */
+	public function test_backwards_compatible_caching( $uri, $expected_file_name ) {
+		$_SERVER['HTTP_HOST'] = 's0.wp.com';
+		$_SERVER['REQUEST_URI'] = $uri;
+
+		$mshots = new TestMshots();
+
+		// Clear the output buffer to avoid errors
+		ob_end_flush();
+
+		$this->assertEquals( $expected_file_name, $mshots->status_string_or_value( 'snapshot_file' ) );
+	}
+
+	public function uri_and_filenames() {
+		return [
+			[ '/invalid', '404' ],
+			[ '/mshots/v1/default', 'default' ],
+			[ '/mshots/v1/https://public-api.wordpress.com/rest/v1/template/demo/rockfield/reynolds?font_base=Fira%20Sans&font_headings=Playfair%20Display&site_title=Reynolds&language=ko',
+			 '/opt/mshots/public_html/thumbnails/ed2/ed271f0f0255e9d784e345dc2f0d8cc48ca26019/e295c5f761af9ac029f49726f50b16b1.jpg' ]
+		];
+	}
+
+    public function test_test() {
+		$this->assertTrue( false );
+    }
 }

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,6 @@
+<phpunit
+        stopOnFailure="false"
+        backupGlobals="false"
+        convertNoticesToExceptions="false"
+        convertWarningsToExceptions="false">
+</phpunit>

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -2,5 +2,6 @@
         stopOnFailure="false"
         backupGlobals="false"
         convertNoticesToExceptions="false"
-        convertWarningsToExceptions="false">
+        convertWarningsToExceptions="false"
+        cacheResult="false">
 </phpunit>


### PR DESCRIPTION
This PR adds some PHP unit tests intended to give us some confidence that newly added functionality is not going to break caching for existing requests.

#### Testing instructions

- The most valuable check is to click through the test details and verify that these do run on CircleCI:
![Notification_Center](https://user-images.githubusercontent.com/5952255/106827029-cb4ebe00-66d3-11eb-9b3f-de6524bea8fb.jpg)
- The php tests are also included when running `npm test` locally, or on their own with `npm run test:php`.