### PR TITLE
Fix cache collisions between screenshots with different screen_height/screen_width

### DIFF
--- a/public_html/class-mshots.php
+++ b/public_html/class-mshots.php
@@ -315,7 +315,7 @@ if ( ! class_exists( 'mShots' ) ) {
 
 			$file = md5( $snap_url . $dimensions );
 
-			$fullpath = self::location_base . '/' . substr( $host, 0, 3 ) . '/' . $host . '/' . $file . $viewport. '.jpg';
+			$fullpath = self::location_base . '/' . substr( $host, 0, 3 ) . '/' . $host . '/' . $file . '.jpg';
 
 			return $fullpath;
 		}

--- a/public_html/class-mshots.php
+++ b/public_html/class-mshots.php
@@ -304,10 +304,17 @@ if ( ! class_exists( 'mShots' ) ) {
 			else
 				$s_host = explode( '/', $url_parts[0] )[0];
 			$host = sha1( strtolower( $s_host ) );
-			$file = md5( $snap_url );
-			$viewport = '';
-			if ( $this->viewport_w != self::VIEWPORT_DEFAULT_W || $this->viewport_h != self::VIEWPORT_DEFAULT_H )
-				$viewport = '_' . $this->viewport_w . 'x' . $this->viewport_h;
+
+			$dimensions = '';
+			if ( $this->viewport_w != self::VIEWPORT_DEFAULT_W || $this->viewport_h != self::VIEWPORT_DEFAULT_H ) {
+				$dimensions = '_vp' . $this->viewport_w . 'x' . $this->viewport_h;
+			}
+			if( $this->screen_width != $this->viewport_w || $this->screen_height != $this->viewport_h ) {
+				$dimensions .= '_screen' . $this->screen_width . 'x' . $this->screen_height;
+			}
+
+			$file = md5( $snap_url . $dimensions );
+
 			$fullpath = self::location_base . '/' . substr( $host, 0, 3 ) . '/' . $host . '/' . $file . $viewport. '.jpg';
 
 			return $fullpath;

--- a/tests/MshotsTest.php
+++ b/tests/MshotsTest.php
@@ -118,8 +118,8 @@ class MshotsTest extends \PHPUnit\Framework\TestCase {
 			$this->assertArrayNotHasKey(
 				$current_filename,
 				$filenames_to_dimensions,
-				'Cache collision: ' . $current_dimensions . ' & '
-					. $filenames_to_dimensions[ $current_filename ]
+				'Cache collision: ' . $current_dimensions
+					. ( empty( $filenames_to_dimensions[ $current_filename ] ) ? '' : ' & ' . $filenames_to_dimensions[ $current_filename ] )
 					. '( filename: ' . $current_filename . ' )'
 			);
 			$filenames_to_dimensions [ $current_filename ] = $current_dimensions;

--- a/tests/MshotsTest.php
+++ b/tests/MshotsTest.php
@@ -78,5 +78,52 @@ class MshotsTest extends \PHPUnit\Framework\TestCase {
 			[ '/mshots/v1/http%3A%2F%2Fcentrodelahoya.es', '/opt/mshots/public_html/thumbnails/9c2/9c2aba28f0d90f31dace1cf44f078ef8a084f07b/b633ca3b16327c692df17133f00d6554.jpg' ]
 		];
 	}
+
+	// Ensure that different viewport and/or screen dimensions get different filenames
+	public function test_unique_caching() {
+		$different_dimensions = [
+			'',
+			'?vpw=320',
+			'?vph=320',
+			'?vph=320&vpw=320',
+			'?screen_height=320',
+			'?screen_width=320',
+			'?screen_height=320&screen_width=320',
+
+			'?vph=640&screen_height=320',
+			'?vph=320&screen_height=640',
+
+			// if screen_height matches vph it's a null-op
+			// '?vph=320&screen_height=320',
+			// '?vph=320&vpw=320&screen_height=320&screen_width=320',
+			// '?vph=640&screen_height=640',
+
+			'?vph=320&vpw=320&screen_height=640',
+			'?vph=320&vpw=320&screen_width=640',
+			'?vph=320&vpw=320&screen_height=640&screen_width=640',
+		];
+
+		$filenames_to_dimensions = array();
+
+		$_SERVER['HTTP_HOST'] = 's0.wp.com';
+
+		foreach ( $different_dimensions as $current_dimensions ) {
+			$_SERVER['REQUEST_URI'] = '/mshots/v1/example.com'  . $current_dimensions;
+
+			$mshots = new TestMshots();
+			// Clear the output buffer to avoid errors
+			ob_end_flush();
+
+			$current_filename = $mshots->get_snapshot_file();
+			$this->assertArrayNotHasKey(
+				$current_filename,
+				$filenames_to_dimensions,
+				'Cache collision: ' . $current_dimensions . ' & '
+					. $filenames_to_dimensions[ $current_filename ]
+					. '( filename: ' . $current_filename . ' )'
+			);
+			$filenames_to_dimensions [ $current_filename ] = $current_dimensions;
+		}
+	}
 }
 


### PR DESCRIPTION
This PR fixes a caching issue where an image requested without a screen_height parameter can be cached and then incorrectly served when requested with the new parameter.

This is done by including the relevant dimensions in the filename hash. Specifically: non-default `vpw` or `vph`, and `screen_height` and `screen_width` if they are different to the `vph`/`vpw` respectively.