### PR TITLE
Update CI Integration

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm i
+    - run: npm i --ignore-scripts
     - run: npm test
       env:
         CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm i --ignore-scripts
+    - run: npm i
     - run: npm test
       env:
         CI: true

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Docker can be used to run the mshots service on OSX for dev/testing purposes:
 - First, give docker permission to mount your dev directory. For Docker Desktop this is in
   `Preferences -> Resources-> File Sharing` where you can add the path to where mshots is checked out.
 - `npm install`: This will also configure the docker container for development and build the docker image (unless you pass `--ignore-scripts`)
+- `npm run config:dev`: This will set some environment variables and build the docker image for development
 - `npm start`: spins up the `mshots` (docker) service in the `mshots-dev` container and starts the mshots (*nix) service within it
 - Ignore the errors about the missing commands. We don't use the kernel extension in the dev container.
 - Check that mshots is available on localhost:8000, e.g. http://localhost:8000/mshots/v1/example.com

--- a/package.json
+++ b/package.json
@@ -24,9 +24,8 @@
 		"status": "docker-compose exec mshots bash -c 'echo mShots Master process: `set -o pipefail; ps ax | grep Master | grep -v grep | awk \"{print \\\\$1}\" || echo not running` ; echo Workers: `ps ax | grep Worker | grep -v grep | wc -l`'",
 		"build": "docker-compose build",
 		"config:core": "rm .env; cp docker-compose-core.yml docker-compose.yml ; npm run build",
-		"config:dev": "echo \"UID=$(id -u)\nGID=$(id -g)\" > .env; docker-compose -f docker-compose-core.yml -f docker-compose-dev-override.yml config > docker-compose.yml; npm run build",
-		"docker:install-chromium-binary": "docker-compose run mshots bash -c 'cd node_modules/puppeteer; node install.js'",
-		"prepare": "npm run config:dev; npm run build; npm run docker:install-chromium-binary"
+		"config:dev": "echo \"UID=$(id -u)\nGID=$(id -g)\" > .env; docker-compose -f docker-compose-core.yml -f docker-compose-dev-override.yml config > docker-compose.yml; npm run build; npm run docker:install-chromium-binary",
+		"docker:install-chromium-binary": "docker-compose run mshots bash -c 'cd node_modules/puppeteer; node install.js'"
 	},
 	"dependencies": {
 		"ip": "^1.1.5",


### PR DESCRIPTION
This PR prevents the CI scripts from building the docker image that it doesn't need. This makes the difference between 4 1/2 minutes installing and about 40s.

Unfortunately, the `--no-scripts` workaround is too blunt for CI, as it also prevents the `sharp` library from installing dependencies we need for testing, so I've disabled the lifecycle magic and added the extra `npm run` statement to the setup docs.