### PR TITLE
Preserve cache keys with a viewport argument

### DIFF
--- a/public_html/class-mshots.php
+++ b/public_html/class-mshots.php
@@ -305,17 +305,17 @@ if ( ! class_exists( 'mShots' ) ) {
 				$s_host = explode( '/', $url_parts[0] )[0];
 			$host = sha1( strtolower( $s_host ) );
 
-			$dimensions = '';
-			if ( $this->viewport_w != self::VIEWPORT_DEFAULT_W || $this->viewport_h != self::VIEWPORT_DEFAULT_H ) {
-				$dimensions = '_vp' . $this->viewport_w . 'x' . $this->viewport_h;
-			}
+			$file = md5( $snap_url );
+			$viewport = '';
+			if ( $this->viewport_w != self::VIEWPORT_DEFAULT_W || $this->viewport_h != self::VIEWPORT_DEFAULT_H )
+				$viewport = '_' . $this->viewport_w . 'x' . $this->viewport_h;
+
+			$capture_size = '';
 			if( $this->screen_width != $this->viewport_w || $this->screen_height != $this->viewport_h ) {
-				$dimensions .= '_screen' . $this->screen_width . 'x' . $this->screen_height;
+				$capture_size .= '_screen' . $this->screen_width . 'x' . $this->screen_height;
 			}
 
-			$file = md5( $snap_url . $dimensions );
-
-			$fullpath = self::location_base . '/' . substr( $host, 0, 3 ) . '/' . $host . '/' . $file . '.jpg';
+			$fullpath = self::location_base . '/' . substr( $host, 0, 3 ) . '/' . $host . '/' . $file . $viewport . $capture_size . '.jpg';
 
 			return $fullpath;
 		}

--- a/tests/MshotsTest.php
+++ b/tests/MshotsTest.php
@@ -112,19 +112,8 @@ class MshotsTest extends \PHPUnit\Framework\TestCase {
 		$_SERVER['HTTP_HOST'] = 's0.wp.com';
 
 		foreach ( $different_dimensions as $current_dimensions ) {
-			$_GET = $current_dimensions;
-
-			$query = implode(
-				'&',
-				array_map(
-					function( $k, $v ) { return $k . '=' . $v; },
-					array_keys( $current_dimensions ),
-					$current_dimensions
-				)
-			);
-			$query = $query ? '?' . $query : '';
-
-			$_SERVER['REQUEST_URI'] = '/mshots/v1/example.com'  . $query;
+			$_SERVER['REQUEST_URI'] = '/mshots/v1/example.com'  . $current_dimensions;
+			$_GET = [];
 
 			$mshots = new TestMshots();
 			// Clear the output buffer to avoid errors
@@ -134,10 +123,10 @@ class MshotsTest extends \PHPUnit\Framework\TestCase {
 			$this->assertArrayNotHasKey(
 				$current_filename,
 				$filenames_to_dimensions,
-				'Cache collision: ' . $query . ' => ' . $current_filename . "\n"
+				'Cache collision: ' . $query . ' => ' . $current_dimensions . "\n"
 					. 'Previous filenames: ' . var_export( $filenames_to_dimensions, true )
 			);
-			$filenames_to_dimensions [ $current_filename ] = $query;
+			$filenames_to_dimensions [ $current_filename ] = $current_dimensions;
 		}
 	}
 }

--- a/tests/MshotsTest.php
+++ b/tests/MshotsTest.php
@@ -55,6 +55,7 @@ class MshotsTest extends \PHPUnit\Framework\TestCase {
 	public function test_backwards_compatible_caching( $uri, $expected_file_name ) {
 		$_SERVER['HTTP_HOST'] = 's0.wp.com';
 		$_SERVER['REQUEST_URI'] = $uri;
+		$_GET = [];
 
 		$mshots = new TestMshots();
 

--- a/tests/MshotsTest.php
+++ b/tests/MshotsTest.php
@@ -87,24 +87,25 @@ class MshotsTest extends \PHPUnit\Framework\TestCase {
 	// Ensure that different viewport and/or screen dimensions get different filenames
 	public function test_unique_caching() {
 		$different_dimensions = [
-			[],
-			[ 'vpw' => '320' ],
-			[ 'vph' => '320' ],
-			[ 'vpw' => '320', 'vph' => '320' ],
-			[ 'screen_height' => '320' ],
-			[ 'screen_width' => '320' ],
-			[ 'screen_height' => '320', 'screen_width' => '320' ],
+			'',
+			'?vpw=320',
+			'?vph=320',
+			'?vph=320&vpw=320',
+			'?screen_height=320',
+			'?screen_width=320',
+			'?screen_height=320&screen_width=320',
 
-			 [ 'vph' => '640', 'screen_height' => '320' ],
+			'?vph=640&screen_height=320',
+			'?vph=320&screen_height=640',
 
 			// if screen_height matches vph it's a null-op
 			// '?vph=320&screen_height=320',
 			// '?vph=320&vpw=320&screen_height=320&screen_width=320',
 			// '?vph=640&screen_height=640',
 
-			[ 'vpw' => '320', 'vph' => '320', 'screen_height' => '640' ],
-			[ 'vpw' => '320', 'vph' => '320', 'screen_width' => '640' ],
-			[ 'vpw' => '320', 'vph' => '320', 'screen_height' => '640', 'screen_width' => '640' ],
+			'?vph=320&vpw=320&screen_height=640',
+			'?vph=320&vpw=320&screen_width=640',
+			'?vph=320&vpw=320&screen_height=640&screen_width=640',
 		];
 
 		$filenames_to_dimensions = array();


### PR DESCRIPTION
This PR restores backward-compatible caching for requests with a `vph` and/or `vpw` accidentally broken in #33.