### PR TITLE
Add scale factor parameter for retina screens

### DIFF
--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -61,7 +61,7 @@ async function init_browser() {
 	return browser;
 }
 
-function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, screen_height ) {
+function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, screen_height, scale_factor ) {
 	let m_uri = p_uri;
 	if ( ! m_uri.match( /^([a-z][a-z0-9+\-.]*):/i ) ) {
 		m_uri = 'http://' + m_uri;
@@ -96,13 +96,12 @@ function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, scre
 			await init_browser();
 		}
 		const page = await browser.newPage();
-
 		await page.setUserAgent( default_UA + ' WordPress.com mShots' );
 		await page.setCacheEnabled( false );
 		await page.setRequestInterception( true );
 		await page._client.send( 'Page.setDownloadBehavior', { behavior: 'deny' } );
 
-		page.setViewport( { width: p_width, height: p_height } );
+		page.setViewport( { width: p_width, height: p_height, deviceScaleFactor: scale_factor } );
 
 		await page.on( 'request', request => {
 			if ( 0 < block_all_code ) {
@@ -384,7 +383,15 @@ function check_site_queue() {
 			var s_details = site_queue[0];
 			site_queue.shift();
 			logger.debug( process.pid + ': snapping: ' + s_details.url );
-			take_snapshot( s_details.url, s_details.file, s_details.width, s_details.height, s_details.screenWidth, s_details.screenHeight );
+			take_snapshot(
+				s_details.url,
+				s_details.file,
+				s_details.width,
+				s_details.height,
+				s_details.screenWidth,
+				s_details.screenHeight,
+				s_details.scaleFactor
+			);
 		}
 	}
 }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -30,6 +30,10 @@ const SCREEN_MIN_H = 320;
 const VIEWPORT_DEFAULT_W = 1280;
 const VIEWPORT_DEFAULT_H = 960;
 
+const SCALE_FACTOR_DEFAULT = 1;
+const SCALE_FACTOR_MIN = 1;
+const SCALE_FACTOR_MAX = 2;
+
 var PortNum = 7777;
 var readyToSendRequests = false;
 var global_queuetotal = 0;
@@ -72,12 +76,16 @@ function validateFileName( request ) {
 		host = url_parts[0].split( "/" )[0];
 	}
 
-	let viewport = '';
+	let suffix = '';
 	if ( request.width != VIEWPORT_DEFAULT_W || request.height != VIEWPORT_DEFAULT_H ) {
-		viewport = '_' + request.width + 'x' + request.height;
+		suffix = '_' + request.width + 'x' + request.height;
 	}
 
-	let s_filename = _cypher.createHash( 'md5' ).update( request.url ).digest( 'hex' ) + viewport + '.jpg';
+	if ( request.scaleFactor != SCALE_FACTOR_DEFAULT ) {
+		suffix += '_' + request.scaleFactor + 'x';
+	}
+
+	let s_filename = _cypher.createHash( 'md5' ).update( request.url ).digest( 'hex' ) + suffix + '.jpg';
 	let s_host = _cypher.createHash( 'sha1' ).update( host ).digest( 'hex' );
 	let s_fullpath = '/opt/mshots/public_html/thumbnails/' + s_host.substring( 0, 3 ) + "/" + s_host + "/" + s_filename;
 
@@ -139,6 +147,10 @@ var HTTPListner = function() {
 					// bound image height by min and max
 					site.screenHeight = Math.max(SCREEN_MIN_H, Math.min(_get['screen_height'], SCREEN_MAX_H))
 				}
+
+				site.scaleFactor = !_get['scale'] || isNaN(_get['scale'])
+					? SCALE_FACTOR_DEFAULT
+					: Math.max(SCALE_FACTOR_MIN, Math.min(parseInt(_get['scale']), SCALE_FACTOR_MAX));
 
 				if ( ! validateFileName( site ) ) {
 					logger.error( process.pid + ': invalid filename: validation failed' );


### PR DESCRIPTION
Right now screenshots appear blurry on "retina" screens, so this PR adds a parameter for the scale factor, which can be either `1` (default) or `2`.

**Testing instructions**

An example use would be: `http://127.0.0.1:8000/mshots/v1/example.com?scale=2&vpw=800&vph=800`

This should return a 1600x1600 image, and a 800x800 image if scale is set to `1`.