### PR TITLE
Fix file validation by matching up filename generation in js and php

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -77,7 +77,12 @@ function validateFileName( request ) {
 		viewport = '_' + request.width + 'x' + request.height;
 	}
 
-	let s_filename = _cypher.createHash( 'md5' ).update( request.url ).digest( 'hex' ) + viewport + '.jpg';
+	let captureSize = '';
+	if( request.screenWidth != request.width || request.screenHeight != request.height ) {
+		captureSize += '_screen' + request.screenWidth + 'x' + request.screenHeight;
+	}
+
+	let s_filename = _cypher.createHash( 'md5' ).update( request.url ).digest( 'hex' ) + viewport + captureSize + '.jpg';
 	let s_host = _cypher.createHash( 'sha1' ).update( host ).digest( 'hex' );
 	let s_fullpath = '/opt/mshots/public_html/thumbnails/' + s_host.substring( 0, 3 ) + "/" + s_host + "/" + s_filename;
 


### PR DESCRIPTION
This PR aligns the filename generation between the javascript and the PHP code to resolve file validation errors when the screen size parameters are used.

Testing Instructions:

- `npm install` if necessary to set up the docker image and configuration.
- `npm start` to spin up a container
- `tail -f logs/mshots.log` to see the debug and error output
- Take a snapshot of any site with a screen_height or screen_width parameter ( e.g. http://localhost:8000/mshots/v1/example.com?screen_height=1300 )
- Check that the log says something like
> [2021-05-07T08:03:28.619] [DEBUG] flog - 12762: snapped: example.com
and not something like
> [2021-05-07T07:37:20.472] [ERROR] flog - 283: invalid filename: validation failed

I'm not sure how production is working without this.