### PR TITLE
Fix shell default value assignment

### DIFF
--- a/mshots_ctl.sh
+++ b/mshots_ctl.sh
@@ -15,7 +15,7 @@ INSTALL_DIR=/opt/mshots
 # port to run the mShots.JS service on
 PORT=7777
 # number of workers to put to work
-MSHOTS_WORKERS?="20"
+MSHOTS_WORKERS=${MSHOTS_WORKERS:-20}
 
 function startservice {
 	if [ ! -d ${INSTALL_DIR} ]; then


### PR DESCRIPTION
This PR fixes the `MSHOTS_WORKER` variables default value by using actual shell syntax for the assignment.

The current behaviour:
```
 /opt/mshots (master) $ docker-compose run mshots ./mshots_ctl.sh start
Creating mshots_mshots_run ... done
./mshots_ctl.sh: line 18: MSHOTS_WORKERS?=20: command not found
./mshots_ctl.sh: line 34: lsmod: command not found
loading vfb
```

To confirm this fix, simply run the `mshot_ctl.sh script` and make sure the `MSHOTS_WORKERS` error is gone:
```
$ docker-compose run mshots ./mshots_ctl.sh start
Creating mshots_mshots_run ... done
./mshots_ctl.sh: line 34: lsmod: command not found
loading vfb
```