### PR TITLE
Increase waiting time before screenshot is captured

### DIFF
--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -24,6 +24,8 @@ const GENERAL_ERROR       = 6;
 const EXIT_UNRESPONSIVE   = 4;
 const EXIT_ERROR_LIMIT    = 5;
 
+const NETWORK_IDLE_TIMEOUT = 3000;
+
 o_log4js.configure( {
 	appenders: {
 		"app": {
@@ -171,6 +173,8 @@ function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, scre
 			}
 		});
 
+		const waitForIdleNetwork = page.waitForNavigation( { waitUntil: 'networkidle0', timeout: NETWORK_IDLE_TIMEOUT } );
+
 		const response = await page.goto( m_uri, { waitUntil: 'networkidle2' } ).
 			catch( e => {
 				logger.error( process.pid + ': Failed to load ' + m_uri + ': ' + e.toString() );
@@ -182,7 +186,15 @@ function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, scre
 			});
 
 		if ( response && response.ok() || page_loaded ) {
-			await page.waitFor( 2000 );
+			try {
+				await waitForIdleNetwork;
+			} catch ( error ) {
+				if ( error instanceof _puppeteer.errors.TimeoutError ) {
+					logger.debug( 'networkidle0 timed out' );
+				} else {
+					throw error;
+				}
+			}
 			makeDirIfRequired( _path.dirname( p_filename ) );
 
 			// Backwards compatibility requires we continue to allow

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -173,7 +173,14 @@ function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, scre
 			}
 		});
 
-		const waitForIdleNetwork = page.waitForNavigation( { waitUntil: 'networkidle0', timeout: NETWORK_IDLE_TIMEOUT } );
+		const waitForIdleNetwork = page.waitForNavigation( { waitUntil: 'networkidle0', timeout: NETWORK_IDLE_TIMEOUT } )
+			.catch( error => {
+				if ( error instanceof _puppeteer.errors.TimeoutError ) {
+					logger.debug( 'networkidle0 timed out' );
+				} else {
+					throw error;
+				}
+			} );
 
 		const response = await page.goto( m_uri, { waitUntil: 'networkidle2' } ).
 			catch( e => {
@@ -186,15 +193,7 @@ function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, scre
 			});
 
 		if ( response && response.ok() || page_loaded ) {
-			try {
-				await waitForIdleNetwork;
-			} catch ( error ) {
-				if ( error instanceof _puppeteer.errors.TimeoutError ) {
-					logger.debug( 'networkidle0 timed out' );
-				} else {
-					throw error;
-				}
-			}
+			await waitForIdleNetwork;
 			makeDirIfRequired( _path.dirname( p_filename ) );
 
 			// Backwards compatibility requires we continue to allow

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -24,7 +24,7 @@ const GENERAL_ERROR       = 6;
 const EXIT_UNRESPONSIVE   = 4;
 const EXIT_ERROR_LIMIT    = 5;
 
-const NETWORK_IDLE_TIMEOUT = 3000;
+const NETWORK_IDLE_TIMEOUT = 3500;
 
 o_log4js.configure( {
 	appenders: {


### PR DESCRIPTION
This increases the page load waiting time from `2000` milliseconds to `3500` milliseconds. Also, by setting `waitUntil` = `networkidle0`  in the options passed to `waitForNavigation()`, the waiting time before the screenshot is captured can potentially be less than that, when network requests finish earlier than that.

The hope is that by increasing the waiting time, we can have a better chance of having a fully loaded page before capturing the screenshot.

**Testing instructions**

- Try to capture the screenshot of a page, e.g. http://127.0.0.1:8000/mshots/v1/example.com
- You should see the "networkidle0 timed out" logged out if 3.5 seconds elapse, or nothing if it finishes earlier. Capturing request heavy pages might trigger the timeout.