### PR TITLE
Add process pid to log message to make error correlation easier and a…

### DIFF
--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -176,7 +176,7 @@ function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, scre
 		const waitForIdleNetwork = page.waitForNavigation( { waitUntil: 'networkidle0', timeout: NETWORK_IDLE_TIMEOUT } )
 			.catch( error => {
 				if ( error instanceof _puppeteer.errors.TimeoutError ) {
-					logger.debug( 'networkidle0 timed out' );
+					logger.debug( process.pid + ': networkidle0 timed out' );
 				} else {
 					throw error;
 				}


### PR DESCRIPTION
…lso be consistent with the rest of the logging.