### PR TITLE
Add special handling for tweet screenshots

### DIFF
--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -5,7 +5,8 @@ const _puppeteer = require( 'puppeteer' );
 const _url       = require( 'url' );
 const _fs        = require( 'fs' );
 const _path      = require( 'path' );
-const _blacklist = require( './blacklist' )
+const _blacklist = require( './blacklist' );
+const _twitter   = require( './twitter' );
 
 const o_log4js  = require( 'log4js' );
 const logger    = o_log4js.getLogger( 'flog' );
@@ -23,8 +24,6 @@ const GENERAL_ERROR       = 6;
 
 const EXIT_UNRESPONSIVE   = 4;
 const EXIT_ERROR_LIMIT    = 5;
-
-const NETWORK_IDLE_TIMEOUT = 3500;
 
 o_log4js.configure( {
 	appenders: {
@@ -173,14 +172,40 @@ function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, scre
 			}
 		});
 
-		const waitForIdleNetwork = page.waitForNavigation( { waitUntil: 'networkidle0', timeout: NETWORK_IDLE_TIMEOUT } )
-			.catch( error => {
-				if ( error instanceof _puppeteer.errors.TimeoutError ) {
-					logger.debug( process.pid + ': networkidle0 timed out' );
-				} else {
-					throw error;
-				}
+		if ( _twitter.isTweetEmbed( m_uri ) ) {
+			const success = await _twitter.takeTweetScreenshot( {
+				page,
+				logger,
+				makeDirIfRequired,
+				url: m_uri,
+				filename: p_filename,
 			} );
+
+			await page.close();
+
+			if ( success ) {
+				logger.debug( process.pid + ': snapped: ' + p_uri );
+			}
+
+			let pages = await browser.pages();
+			pages.forEach( function( p ) {
+				p.close();
+			});
+
+			process.send({
+				replytype: 'queue-del',
+				workerid: process.pid,
+				payload: {
+					status: success ? SUCCESS : GENERAL_ERROR,
+					url   : p_uri,
+					file  : p_filename,
+				}
+			});
+
+			time_downloading = 0;
+			downloading = false;
+			return;
+		}
 
 		const response = await page.goto( m_uri, { waitUntil: 'networkidle2' } ).
 			catch( e => {
@@ -193,7 +218,7 @@ function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, scre
 			});
 
 		if ( response && response.ok() || page_loaded ) {
-			await waitForIdleNetwork;
+			await page.waitFor( 2000 );
 			makeDirIfRequired( _path.dirname( p_filename ) );
 
 			// Backwards compatibility requires we continue to allow

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -1,0 +1,99 @@
+
+'use strict';
+
+const _path = require( 'path' );
+
+// time in milliseconds to wait after the last response before taking the screenshot
+const WAIT_AFTER_RESPONSE = 1000;
+const LOOP_SLEEP_TIME = 500;
+
+// maximum waiting time in milliseconds for requests to finish
+const TIMEOUT = 15000;
+
+const sleep = timeInMs => new Promise( resolve => setTimeout( resolve, timeInMs ) );
+
+const isTweetEmbed = url => url.startsWith( 'https://platform.twitter.com/embed/index.html?' );
+
+const snapTweet = async ( { page, filename, logger, makeDirIfRequired } ) => {
+    const elements = await page.$x( '//*[@id="app"]/div/div/div' );
+    if ( elements.length !== 1 ) {
+        logger.error( `${process.pid}: xpath selector returned ${elements.length} elements` );
+        return false;
+    }
+    makeDirIfRequired( _path.dirname( filename ) );
+    await elements[0].screenshot( { path: filename, type: 'jpeg', quality: 90 } );
+    return true;
+};
+
+const takeTweetScreenshot = async ( { page, url, filename, logger, makeDirIfRequired } ) => {
+    let isTweetInfoLoaded = false;
+    let lastResponseTime = Date.now();
+    const activeRequests = [];
+
+    await page.on( 'request', request => {
+        if ( isTweetInfoLoaded ) {
+            activeRequests.push( request.url() );
+        }
+    } );
+
+    await page.on( 'response', response => {
+        const requestUrl = response.request().url();
+        if ( requestUrl.startsWith( 'https://cdn.syndication.twimg.com/tweet' ) ) {
+            isTweetInfoLoaded = true;
+            lastResponseTime = Date.now();
+        } else {
+            const index = activeRequests.indexOf( requestUrl );
+            if (index > -1) {
+                activeRequests.splice( index, 1 );
+                lastResponseTime = Date.now();
+            }
+        }
+    } );
+
+    const startTime = Date.now();
+    let success = false;
+
+    const response = await page.goto( url )
+        .catch( e => {
+            logger.error( process.pid + ': Failed to load ' + url + ': ' + e.toString() );
+        } );
+
+    if ( ! response ) {
+        return false;
+    }
+
+    await ( async () => {
+        while ( true ) {
+            if ( isTweetInfoLoaded && activeRequests.length === 0 ) {
+                const currentLastResponseTime = lastResponseTime;
+                const waitingTime = currentLastResponseTime + WAIT_AFTER_RESPONSE - Date.now();
+
+                if ( waitingTime > 0 ) {
+                    await sleep( waitingTime );
+                }
+
+                if ( currentLastResponseTime === lastResponseTime ) {
+                    success = await snapTweet( { page, filename, logger, makeDirIfRequired } );
+                    return;
+                }
+            }
+
+            if ( Date.now() - startTime >= TIMEOUT ) {
+                logger.error( `${process.pid}: Timed out waiting for requests to finish: ${url}` );
+                success = false;
+                return;
+            }
+
+            await sleep( LOOP_SLEEP_TIME );
+        }
+    } )();
+
+    return success;
+};
+
+const exported = {
+    isTweetEmbed,
+    takeTweetScreenshot,
+};
+
+module.exports = exported;


### PR DESCRIPTION
This PR adds special handling for taking tweet embed screenshots, as well as undoes changes introduced in #41.

**Testing instructions**

Example URL that can be used to test new changes: http://127.0.0.1:8000/mshots/v1/https%3A//platform.twitter.com/embed/index.html%3Fdnt%3Dfalse%26embedId%3Dtwitter-widget-0%26frame%3Dfalse%26hideCard%3Dfalse%26hideThread%3Dtrue%26id%3D1416034406528073728%26lang%3Den

The screenshot should only contain the tweet, and nothing else (not a full page screenshot).

Other URLs should not be affected by this change.