### PR TITLE
Change what we treat as an error for xpath twitter selector

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -16,8 +16,8 @@ const isTweetEmbed = url => url.startsWith( 'https://platform.twitter.com/embed/
 
 const snapTweet = async ( { page, filename, logger, makeDirIfRequired } ) => {
     const elements = await page.$x( '//*[@id="app"]//article' );
-    if ( elements.length !== 1 ) {
-        logger.error( `${process.pid}: xpath selector returned ${elements.length} elements` );
+    if ( elements.length < 1 ) {
+        logger.error( `${process.pid}: xpath selector returned no elements` );
         return false;
     }
     makeDirIfRequired( _path.dirname( filename ) );


### PR DESCRIPTION
We just want the article. If there's more than 1, all cool.