### PR TITLE
Add format param to allow saving PNGs

### DIFF
--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -64,7 +64,7 @@ async function init_browser() {
 	return browser;
 }
 
-function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, screen_height, scale_factor ) {
+function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, screen_height, scale_factor, quality = 90 ) {
 	let m_uri = p_uri;
 	if ( ! m_uri.match( /^([a-z][a-z0-9+\-.]*):/i ) ) {
 		m_uri = 'http://' + m_uri;
@@ -251,7 +251,7 @@ function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, scre
 				? Math.min( screen_width, documentWidth )
 				: p_width;
 
-			await page.screenshot( { path: p_filename, fullPage: false, type: 'jpeg', quality: 90, clip: {
+			await page.screenshot( { path: p_filename, fullPage: false, type: 'jpeg', quality, clip: {
 				x: 0,
 				y: 0,
 				width: snapshotWidth,
@@ -429,7 +429,8 @@ function check_site_queue() {
 				s_details.height,
 				s_details.screenWidth,
 				s_details.screenHeight,
-				s_details.scaleFactor
+				s_details.scaleFactor,
+				s_details.quality,
 			);
 		}
 	}

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -24,6 +24,7 @@ const GENERAL_ERROR       = 6;
 
 const EXIT_UNRESPONSIVE   = 4;
 const EXIT_ERROR_LIMIT    = 5;
+const DEFAULT_FORMAT 	  = 'jpeg'
 
 o_log4js.configure( {
 	appenders: {
@@ -64,7 +65,7 @@ async function init_browser() {
 	return browser;
 }
 
-function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, screen_height, scale_factor, quality = 90 ) {
+function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, screen_height, scale_factor, format = 'jpeg' ) {
 	let m_uri = p_uri;
 	if ( ! m_uri.match( /^([a-z][a-z0-9+\-.]*):/i ) ) {
 		m_uri = 'http://' + m_uri;
@@ -251,12 +252,18 @@ function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, scre
 				? Math.min( screen_width, documentWidth )
 				: p_width;
 
-			await page.screenshot( { path: p_filename, fullPage: false, type: 'jpeg', quality, clip: {
+			const config = { path: p_filename, fullPage: false, type: format, clip: {
 				x: 0,
 				y: 0,
 				width: snapshotWidth,
 				height: snapshotHeight
-			} } );
+			} }
+
+			if ( format === DEFAULT_FORMAT ) {
+				config.quality = 90
+			}
+
+			await page.screenshot( config );
 
 			await page.close();
 			logger.debug( process.pid + ': snapped: ' + p_uri );
@@ -430,7 +437,7 @@ function check_site_queue() {
 				s_details.screenWidth,
 				s_details.screenHeight,
 				s_details.scaleFactor,
-				s_details.quality,
+				s_details.format,
 			);
 		}
 	}

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -27,7 +27,7 @@ const SCREEN_MAX_H = 7680;
 const SCREEN_MIN_W = 320;
 const SCREEN_MIN_H = 320;
 
-const DEFAULT_QUALITY = 90;
+const DEFAULT_FORMAT = 'jpeg';
 
 const VIEWPORT_DEFAULT_W = 1280;
 const VIEWPORT_DEFAULT_H = 960;
@@ -91,14 +91,13 @@ function validateFileName( request ) {
 		suffix += '_' + request.scaleFactor + 'x';
 	}
 
-	suffix += `_${request.quality}q`;
+	const extension = request.format === DEFAULT_FORMAT ? '.jpg' : '.png'
 
-	let s_filename = _cypher.createHash( 'md5' ).update( request.url ).digest( 'hex' ) + suffix + '.jpg';
-	logger.error(s_filename);
-
+	let s_filename = _cypher.createHash( 'md5' ).update( request.url ).digest( 'hex' ) + suffix + extension;
+	
 	let s_host = _cypher.createHash( 'sha1' ).update( host ).digest( 'hex' );
 	let s_fullpath = '/opt/mshots/public_html/thumbnails/' + s_host.substring( 0, 3 ) + "/" + s_host + "/" + s_filename;
-
+	
 	return ( s_fullpath == request.file );
 }
 
@@ -128,10 +127,10 @@ var HTTPListner = function() {
 				site.url = _get['url'];
 				site.file =_get['f'];
 
-				if( _get['quality'] ) {
-					site.quality = parseInt( _get['quality'] );
+				if ( _get['format'] ) {
+					site.format = _get['format'];
 				} else {
-					site.quality = DEFAULT_QUALITY;
+					site.format = DEFAULT_FORMAT;
 				}
 
 				if ( !_get['vpw'] || isNaN( _get['vpw'] ) ) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -27,6 +27,8 @@ const SCREEN_MAX_H = 7680;
 const SCREEN_MIN_W = 320;
 const SCREEN_MIN_H = 320;
 
+const DEFAULT_QUALITY = 90;
+
 const VIEWPORT_DEFAULT_W = 1280;
 const VIEWPORT_DEFAULT_H = 960;
 
@@ -89,7 +91,11 @@ function validateFileName( request ) {
 		suffix += '_' + request.scaleFactor + 'x';
 	}
 
+	suffix += `_${request.quality}q`;
+
 	let s_filename = _cypher.createHash( 'md5' ).update( request.url ).digest( 'hex' ) + suffix + '.jpg';
+	logger.error(s_filename);
+
 	let s_host = _cypher.createHash( 'sha1' ).update( host ).digest( 'hex' );
 	let s_fullpath = '/opt/mshots/public_html/thumbnails/' + s_host.substring( 0, 3 ) + "/" + s_host + "/" + s_filename;
 
@@ -122,6 +128,11 @@ var HTTPListner = function() {
 				site.url = _get['url'];
 				site.file =_get['f'];
 
+				if( _get['quality'] ) {
+					site.quality = parseInt( _get['quality'] );
+				} else {
+					site.quality = DEFAULT_QUALITY;
+				}
 
 				if ( !_get['vpw'] || isNaN( _get['vpw'] ) ) {
 					site.width = VIEWPORT_DEFAULT_W;

--- a/public_html/class-mshots.php
+++ b/public_html/class-mshots.php
@@ -17,7 +17,8 @@ if ( ! class_exists( 'mShots' ) ) {
 		const VIEWPORT_MIN_H = 320;
 		const VIEWPORT_DEFAULT_W = 1280;
 		const VIEWPORT_DEFAULT_H = 960;
-		const DEFAULT_QUALITY = 90;
+		const DEFAULT_FORMAT = 'jpeg';
+		const ALLOWED_FORMATS = ['png', 'jpeg'];
 		const SCREEN_MAX_W = 1600;
 		const SCREEN_MAX_H = 3600;
 		const SCALE_FACTOR_VALUES = [1, 2];
@@ -78,10 +79,10 @@ if ( ! class_exists( 'mShots' ) ) {
 				$this->viewport_w = min( max( self::VIEWPORT_MIN_W, intval( $_GET[ 'vpw' ] ) ), self::VIEWPORT_MAX_W );
 			}
 
-			if ( isset( $_GET[ 'quality' ] ) && is_numeric( $_GET[ 'quality' ] ) ) {
-				$this->quality = intval( $_GET[ 'quality' ] );
+			if ( isset( $_GET[ 'format' ] ) && in_array( $_GET[ 'format' ], self::ALLOWED_FORMATS ) ) {
+				$this->format = $_GET[ 'format' ];
 			} else {
-				$this->quality = self::DEFAULT_QUALITY;
+				$this->format = self::DEFAULT_FORMAT;
 			}
 
 			if ( isset( $_GET[ 'vph' ] ) ) {
@@ -154,9 +155,7 @@ if ( ! class_exists( 'mShots' ) ) {
 				$requeue_url .= '&scale=' . $this->scale_factor;
 			}
 
-			if ( $this->quality != self::DEFAULT_QUALITY ) {
-				$requeue_url .= '&quality=' . $this->quality;
-			}
+			$requeue_url .= '&format=' . $this->format;
 
 			$ch = curl_init( $requeue_url );
 			curl_setopt( $ch, CURLOPT_TIMEOUT, 10 );
@@ -199,7 +198,7 @@ if ( ! class_exists( 'mShots' ) ) {
 					header( "Cache-Control: public, max-age=43200" );
 				}
 			}
-			$this->image_resize_and_output( $this->snapshot_file, $this->quality );
+			$this->image_resize_and_output( $this->snapshot_file, $this->format );
 		}
 
 		public function must_requeue() {
@@ -234,10 +233,10 @@ if ( ! class_exists( 'mShots' ) ) {
 			header( 'Pragma: no-cache' );
 		}
 
-		private function image_resize_and_output( $image_filename, $quality ) {
+		private function image_resize_and_output( $image_filename, $format ) {
 			try {
 				if ( $image = imagecreatefromstring( file_get_contents( $image_filename ) ) ) {
-					header( 'Content-Type: image/jpeg' );
+					header( "Content-Type: image/$format" );
 					$width = imagesx( $image );
 					$height = imagesy( $image );
 					$original_aspect = $width / $height;
@@ -253,7 +252,11 @@ if ( ! class_exists( 'mShots' ) ) {
 
 					$thumb_aspect = $thumb_width / $thumb_height;
 					if ( $thumb_width == $width && $thumb_height == $height ) {
-						imagejpeg( $image, null, $quality );
+						if( $format === 'jpeg' ) {
+							imagejpeg( $image, null, 90 );
+						} else {
+							imagepng( $image );
+						}
 						return;
 					}
 
@@ -267,7 +270,12 @@ if ( ! class_exists( 'mShots' ) ) {
 					$thumb = imagecreatetruecolor( $thumb_width, $thumb_height );
 					$indentX = 0 - ( $new_width - $thumb_width ) / 2;
 					imagecopyresampled( $thumb, $image, $indentX, 0, 0, 0, $new_width, $new_height, $width, $height );
-					imagejpeg( $thumb, null, $quality );
+					if( $format === 'jpeg' ) {
+						imagejpeg( $thumb, null, 90 );
+					} else {
+						imagepng( $thumb );
+					}
+					return;
 				} else {
 					error_log( "error processing filename : " . $image_filename );
 					if ( 0 < strlen( $image_filename ) ) {
@@ -340,10 +348,10 @@ if ( ! class_exists( 'mShots' ) ) {
 			if ( $this->scale_factor != self::SCALE_FACTOR_DEFAULT ) {
 				$suffix .= "_{$this->scale_factor}x";
 			}
+			
+			$extension = $this->format === 'jpeg' ? '.jpg' : '.png';
 
-			$suffix .= "_{$this->quality}q";			
-
-			$fullpath = self::location_base . '/' . substr( $host, 0, 3 ) . '/' . $host . '/' . $file . $suffix . '.jpg';
+			$fullpath = self::location_base . '/' . substr( $host, 0, 3 ) . '/' . $host . '/' . $file . $suffix . $extension;
 
 			return $fullpath;
 		}


### PR DESCRIPTION
~~This adds`quality` param to allow creating higher quality images. The simpler and safer solution would be to change the default quality to 100 instead of 90.~~

This adds a `format` param to allow choosing between `jpeg` and `png`. It defaults to `jpeg`. I tried JPEG quality 100, and it's still subpar. And sadly, webp is not supported by neither PHP nor Puppeteer.

The quality of images is key to user conversion in Link in Bio flow. To see how pixelated current screenshots are, please visit https://wordpress.com/setup/patterns?flow=link-in-bio.

### Testing instructions
1. Clone this repo.
2. Make sure you have Docker installed.
3. Run `npm start`. 
4. Visit http://localhost:8000/mshots/v1/page.com and verify that you'll get a JPEG (by checking DevTools > Network tab).
5. Visit http://localhost:8000/mshots/v1/page.com?format=jpeg and verify that you'll get a JPEG.
6. Visit http://localhost:8000/mshots/v1/page.com?format=png and verify that you'll get a PNG.
7. Visit http://localhost:8000/mshots/v1/page.com?format=xml and verify that you'll get a JPEG.