### PR TITLE
page.waitForTimeout removed in puppeteer >=22

### DIFF
--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -222,7 +222,7 @@ function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, scre
 			});
 
 		if ( response && response.ok() || page_loaded ) {
-			await page.waitForTimeout( 2000 );
+			await new Promise( r => setTimeout( r, 2000 ) );
 			makeDirIfRequired( _path.dirname( p_filename ) );
 
 			// Backwards compatibility requires we continue to allow


### PR DESCRIPTION
use a vanilla JS promise

https://github.com/puppeteer/puppeteer/pull/11780