### PR TITLE
more puppeteer >=22 breaking changes

### DIFF
--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -55,7 +55,7 @@ async function init_browser() {
 	const args = process.env.MSHOTS_CONTAINERIZED ? [ '--no-sandbox' ] : [];
   const executablePath = process.env.ARCH === "arm64" ? "chromium" : undefined;
 
-	browser = await _puppeteer.launch( { headless: true, timeout: 30000, ignoreHTTPSErrors: true, args, executablePath } ).
+	browser = await _puppeteer.launch( { headless: 'shell', timeout: 30000, ignoreHTTPSErrors: true, args, executablePath } ).
 		catch( e => {
 			logger.error( process.pid + ': Failed to launch the browser: ' + e.toString() );
 			process.exit( EXIT_UNRESPONSIVE );

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -15,7 +15,7 @@ const sleep = timeInMs => new Promise( resolve => setTimeout( resolve, timeInMs 
 const isTweetEmbed = url => url.startsWith( 'https://platform.twitter.com/embed/index.html?' );
 
 const snapTweet = async ( { page, filename, logger, makeDirIfRequired } ) => {
-    const elements = await page.$x( '//*[@id="app"]//article' );
+    const elements = await page.$$( 'xpath/.//*[@id="app"]//article' );
     if ( elements.length < 1 ) {
         logger.error( `${process.pid}: xpath selector returned no elements` );
         return false;


### PR DESCRIPTION
$x was removed in favor of $$
https://github.com/puppeteer/puppeteer/pull/11782

also seems new headless mode is using more cpu
so switch to 'shell' which should be closer to old headless mode...
https://pptr.dev/guides/headless-modes/