### PR TITLE
Allow forwarding user agent via URL flag

### DIFF
--- a/config/mshots.conf
+++ b/config/mshots.conf
@@ -1,2 +1,3 @@
 # mShots.JS config file
+user-agent	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) WordPress.com mShots Safari/537.36
 max-redirects	2

--- a/config/mshots.conf
+++ b/config/mshots.conf
@@ -1,3 +1,2 @@
 # mShots.JS config file
-user-agent	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) WordPress.com mShots Safari/537.36
 max-redirects	2

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -65,7 +65,7 @@ async function init_browser() {
 	return browser;
 }
 
-function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, screen_height, scale_factor, format = DEFAULT_FORMAT ) {
+function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, screen_height, scale_factor, format = DEFAULT_FORMAT, user_agent ) {
 	let m_uri = p_uri;
 	if ( ! m_uri.match( /^([a-z][a-z0-9+\-.]*):/i ) ) {
 		m_uri = 'http://' + m_uri;
@@ -101,7 +101,11 @@ function take_snapshot( p_uri, p_filename, p_width, p_height, screen_width, scre
 		}
 		const page = await browser.newPage();
 
-		await page.setUserAgent( default_UA + ' WordPress.com mShots' );
+		if ( user_agent ) {
+			await page.setUserAgent( user_agent );
+		} else {
+			await page.setUserAgent( default_UA + ' WordPress.com mShots' );
+		}
 		await page.setCacheEnabled( false );
 		await page.setRequestInterception( true );
 		await page._client().send( 'Page.setDownloadBehavior', { behavior: 'deny' } );
@@ -437,7 +441,8 @@ function check_site_queue() {
 				s_details.screenWidth,
 				s_details.screenHeight,
 				s_details.scaleFactor,
-				s_details.format
+				s_details.format,
+				s_details.user_agent
 			);
 		}
 	}

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -136,6 +136,10 @@ var HTTPListner = function() {
 					site.format = _get['format'];
 				}
 
+				if ( _get['user_agent'] ) {
+					site.user_agent = _get['user_agent'];
+				}
+
 				if ( !_get['vpw'] || isNaN( _get['vpw'] ) ) {
 					site.width = VIEWPORT_DEFAULT_W;
 				} else {

--- a/public_html/class-mshots.php
+++ b/public_html/class-mshots.php
@@ -96,6 +96,10 @@ if ( ! class_exists( 'mShots' ) ) {
 				$this->viewport_h = min( max( self::VIEWPORT_MIN_H, intval( $_GET[ 'vph' ] ) ), self::VIEWPORT_MAX_H );
 			}
 
+			if ( isset( $_GET[ 'forward_user_agent' ] ) ) {
+				$this->user_agent = $_SERVER[ 'HTTP_USER_AGENT' ];
+			}
+
 			if ( isset( $_GET[ 'screen_width' ] ) ) {
 				$this->screen_width = intval( $_GET[ 'screen_width' ] );
 				if ( $this->screen_width > self::SCREEN_MAX_W ) {
@@ -160,6 +164,10 @@ if ( ! class_exists( 'mShots' ) ) {
 
 			if ( $this->scale_factor != self::SCALE_FACTOR_DEFAULT ) {
 				$requeue_url .= '&scale=' . $this->scale_factor;
+			}
+
+			if ( isset( $this->user_agent ) ) {
+				$requeue_url .= '&user_agent=' . rawurlencode( $this->user_agent );
 			}
 
 			$requeue_url .= '&format=' . $this->format;


### PR DESCRIPTION
This adds `forward_user_agent` flag to allow forwarding the user agent of the viewer. Some sites (like Wix) don't allow Headless Chrome user agents from screenshotting sites.

I came up with this way to prevent hard-coding a value and creating maintenance costs. 

Fixes: https://github.com/Automattic/wp-calypso/issues/45586 (the latter part, where users get 403)

### Testing steps

1. Clone this repo and checkout this branch.
2. Run `npm i`. This takes ~5 mins.
3. Run `npm start`. 
4. Go to localhost:8000/mshots/v1/https%3A%2F%2Fhttpbin.io%2Fuser-agent. This site gives you your user agent. The string in the screenshot should contain `HeadlessChrome`.
5. Go to `public_html/thumbnails` and delete its contents.
6. Go to  localhost:8000/mshots/v1/https://httpbin.io/user-agent?forward_user_agent=1.
7. The user agent in the screenshot should be identical to your own agent. You can view your agent by viewing https://httpbin.io/user-agent.